### PR TITLE
docs: Add Architecture Decision Records (ADRs)

### DIFF
--- a/docs/adr/ADR-001-s3-file-storage.md
+++ b/docs/adr/ADR-001-s3-file-storage.md
@@ -1,0 +1,163 @@
+# ADR-001: Amazon S3 for File Storage
+
+**Status:** Accepted
+**Date:** 2025-10-31
+**Deciders:** Development Team
+
+## Context
+
+Causalytics is a causal analysis platform that requires users to upload CSV datasets for performing Difference-in-Differences (DiD) analysis. The platform needs a reliable, scalable solution for storing user-uploaded files that:
+
+- Handles multiple concurrent file uploads from different users
+- Scales storage capacity as the user base grows
+- Provides secure access control for file retrieval
+- Maintains file metadata and associations with user projects
+- Supports files up to 10MB in size
+- Ensures durability and availability of uploaded data
+
+The application architecture consists of a Flask backend and React frontend, with PostgreSQL for relational data. We need to decide where and how to store user-uploaded CSV files.
+
+## Decision
+
+We will use **Amazon S3 (Simple Storage Service)** as the file storage backend for all user-uploaded datasets.
+
+### Implementation Details:
+
+1. **S3 Integration via boto3**
+   - Use AWS SDK for Python (boto3) to interact with S3
+   - Configure S3 client with AWS credentials from environment variables
+   - Region configurable via `AWS_REGION` (defaults to `us-east-1`)
+
+2. **File Organization Structure**
+   ```
+   s3://bucket-name/uploads/project_{project_id}/{uuid}.csv
+   ```
+   - Files organized by project ID for logical grouping
+   - UUID-based filenames prevent naming conflicts and overwrites
+   - Original filename preserved in S3 metadata and database
+
+3. **Dual Storage Approach**
+   - **S3**: Stores actual file content
+   - **PostgreSQL**: Stores file metadata (filename, s3_key, schema_info)
+   - Database `Dataset` model maintains reference via unique `s3_key` column
+
+4. **File Validation**
+   - CSV format only (validated by file extension)
+   - 10MB size limit enforced before upload
+   - Content-Type set to `text/csv` during upload
+
+5. **Metadata Storage**
+   - S3 object metadata includes:
+     - `original-filename`: User's original filename
+     - `project-id`: Associated project identifier
+     - `uploaded-by`: User ID who uploaded the file
+   - PostgreSQL stores: `file_name`, `s3_key`, `schema_info`, `project_id`
+
+6. **Security**
+   - AWS credentials stored in environment variables (not in code)
+   - JWT authentication required for all upload/access operations
+   - Project ownership validated before file operations
+   - S3 bucket access controlled via IAM policies
+
+## Consequences
+
+### Positive
+
+- **Scalability**: S3 automatically scales to handle any amount of data without infrastructure management
+- **Durability**: 99.999999999% (11 9's) durability ensures data is not lost
+- **Cost-Effective**: Pay-per-use model with no upfront costs; cheaper than managing storage infrastructure
+- **Performance**: High availability and low latency for file operations globally
+- **Separation of Concerns**: File storage separated from application and database servers
+- **Reduced Server Load**: Offloads file storage from backend server, freeing resources for computation
+- **Built-in Features**: Versioning, lifecycle policies, and encryption available out-of-the-box
+- **Developer Experience**: boto3 library is mature, well-documented, and actively maintained
+
+### Negative
+
+- **Vendor Lock-in**: Tightly coupled to AWS ecosystem; migration to other providers requires refactoring
+- **External Dependency**: Relies on AWS availability; S3 outages impact file operations
+- **Cost Unpredictability**: Costs can increase unexpectedly with high usage (though still typically lower than alternatives)
+- **Network Latency**: File operations require network round-trips to AWS, adding latency vs. local storage
+- **Complexity**: Additional configuration required (AWS credentials, bucket setup, IAM policies)
+- **Testing Challenges**: Requires mocking S3 in tests or using localstack for integration tests
+- **Environment Configuration**: Need to manage AWS credentials securely across development, staging, and production
+
+## Alternatives Considered
+
+### 1. Local Filesystem Storage
+**Description**: Store files directly on the Flask server's filesystem.
+
+**Pros**:
+- Simplest implementation
+- No external dependencies or costs
+- Faster access (no network latency)
+- Easier local development
+
+**Cons**:
+- Does not scale horizontally (multiple server instances need shared filesystem)
+- Manual backup and disaster recovery required
+- Limited by server disk capacity
+- File loss risk if server fails
+- Difficult to manage as data grows
+
+**Rejection Reason**: Does not meet scalability requirements for a production application.
+
+### 2. PostgreSQL Binary Storage (BYTEA)
+**Description**: Store file content as binary data in PostgreSQL database.
+
+**Pros**:
+- Single storage system (no external service needed)
+- ACID transactions for file operations
+- Backup/restore handled with database backups
+
+**Cons**:
+- Poor database performance with large files
+- Increases database size significantly
+- Expensive backup costs
+- Not designed for blob storage (inefficient)
+- Difficult to serve files efficiently
+
+**Rejection Reason**: PostgreSQL is optimized for structured data, not file storage. This would degrade database performance.
+
+### 3. Alternative Cloud Storage (Google Cloud Storage, Azure Blob Storage)
+**Description**: Use competing cloud storage services.
+
+**Pros**:
+- Similar features and benefits to S3
+- May have better pricing in some regions
+- Comparable durability and availability
+
+**Cons**:
+- Team has more experience with AWS
+- boto3 has excellent Python support
+- S3 is the most mature object storage solution
+- Existing infrastructure may already use AWS
+
+**Rejection Reason**: S3 is the industry standard with the best Python ecosystem support. No compelling reason to choose alternatives.
+
+### 4. Self-Hosted Object Storage (MinIO)
+**Description**: Deploy self-hosted S3-compatible object storage.
+
+**Pros**:
+- S3-compatible API (works with boto3)
+- No vendor lock-in
+- Potentially lower costs at scale
+- Full control over infrastructure
+
+**Cons**:
+- Requires infrastructure management and maintenance
+- Need to handle backups, monitoring, and disaster recovery
+- No built-in global distribution
+- Operational complexity for a small team
+- Upfront infrastructure costs
+
+**Rejection Reason**: Operational overhead outweighs benefits for this stage of the project. Can reconsider if cost becomes prohibitive.
+
+---
+
+## References
+
+- [AWS S3 Documentation](https://docs.aws.amazon.com/s3/)
+- [boto3 S3 Client Documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html)
+- File implementation: `backend/routes/projects.py:164-253`
+- Database model: `backend/models.py:51-69`

--- a/docs/adr/ADR-002-rest-api-design.md
+++ b/docs/adr/ADR-002-rest-api-design.md
@@ -1,0 +1,292 @@
+# ADR-002: RESTful API Design with Flask Blueprints
+
+**Status:** Accepted
+**Date:** 2025-10-31
+**Deciders:** Development Team
+
+## Context
+
+Causalytics requires a backend API to support user authentication, project management, file uploads, and causal analysis features. The API needs to:
+
+- Provide clear, predictable endpoints for the React frontend
+- Support authentication and authorization for multi-user access
+- Scale as new features are added without becoming monolithic
+- Follow industry standards for maintainability and developer experience
+- Handle CORS for cross-origin requests from the frontend
+- Provide consistent error handling and response formats
+- Be testable, maintainable, and well-documented
+
+The backend is built with Flask (Python), and we need to establish architectural patterns that will guide API development throughout the project lifecycle.
+
+## Decision
+
+We will implement a **RESTful API architecture** using **Flask Blueprints** for modular route organization, with **JWT Bearer token authentication** for security.
+
+### Core Design Principles:
+
+#### 1. Blueprint-Based Modularization
+- Organize routes into separate blueprints by domain/resource:
+  - `auth_bp`: Authentication endpoints (`/api/auth/*`)
+  - `projects_bp`: Project and file management (`/api/projects/*`)
+  - `analysis_bp`: Data analysis operations (`/api/analysis/*`)
+- Each blueprint is self-contained in `routes/{domain}.py`
+- URL prefixes defined at blueprint level for consistency
+
+#### 2. RESTful Resource Naming Conventions
+- **URL Structure**: `/api/{resource}/{id}/{sub-resource}`
+  - Examples:
+    - `GET /api/projects` - List all projects
+    - `GET /api/projects/5` - Get project #5
+    - `POST /api/projects/5/upload` - Upload file to project #5
+    - `GET /api/projects/5/datasets` - List datasets in project #5
+
+- **Resource Naming Rules**:
+  - Use plural nouns for collections (`/projects`, `/datasets`, `/analyses`)
+  - Use kebab-case for multi-word resources (future: `/user-profiles`)
+  - Avoid verbs in URLs (actions implied by HTTP method)
+  - Nest related resources under parent resources
+
+#### 3. HTTP Methods and Semantics
+- `POST`: Create new resources, perform actions
+  - Returns `201 Created` for resource creation
+  - Returns `200 OK` for actions that don't create resources
+- `GET`: Retrieve resources (read-only, idempotent)
+  - Returns `200 OK` with resource data
+- `PUT`: Full resource update (future use)
+- `PATCH`: Partial resource update (future use)
+- `DELETE`: Remove resources (future use)
+
+#### 4. Authentication Strategy
+- **JWT (JSON Web Tokens)** via Flask-JWT-Extended
+- **Two-token system**:
+  - Access token: 1 hour expiration (configurable via env)
+  - Refresh token: 30 days expiration (configurable via env)
+- **Token format**: `Authorization: Bearer <token>`
+- **Protected routes**: Decorated with `@jwt_required()`
+- **Token payload**: User ID stored as string for JWT compatibility
+- **Refresh flow**: `/api/auth/refresh` endpoint for token renewal
+
+#### 5. Response Format Standards
+**Success Response Structure:**
+```json
+{
+  "message": "Descriptive success message",
+  "data_field": { ... },
+  "related_field": [ ... ]
+}
+```
+
+**Error Response Structure:**
+```json
+{
+  "error": "Clear, actionable error message"
+}
+```
+
+**Status Code Usage:**
+- `200 OK`: Successful GET/POST actions
+- `201 Created`: Successful resource creation
+- `400 Bad Request`: Invalid client input
+- `401 Unauthorized`: Missing/invalid authentication
+- `403 Forbidden`: Authenticated but lacks permission
+- `404 Not Found`: Resource doesn't exist
+- `409 Conflict`: Resource already exists (e.g., duplicate email)
+- `500 Internal Server Error`: Unexpected server errors
+
+#### 6. Error Handling Pattern
+```python
+try:
+    # Business logic
+    db.session.commit()
+    return jsonify({"result": data}), 200
+except ValueError as e:
+    return jsonify({"error": "Invalid input"}), 400
+except Exception as e:
+    db.session.rollback()
+    logger.error("Operation failed: %s", str(e))
+    return jsonify({"error": "Operation failed"}), 500
+```
+
+- All routes wrapped in try-except blocks
+- Database rollback on errors
+- Structured logging for debugging
+- Generic error messages to clients (no stack traces in production)
+
+#### 7. Configuration Management
+- All sensitive configuration via environment variables
+- Required variables validated at application startup
+- Configuration categories:
+  - **JWT**: `JWT_SECRET_KEY`, `JWT_ACCESS_TOKEN_EXPIRES`, `JWT_REFRESH_TOKEN_EXPIRES`
+  - **Database**: `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`, `DB_NAME`
+  - **AWS**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET_NAME`
+  - **CORS**: `CORS_ORIGINS` (comma-separated list)
+
+#### 8. CORS Configuration
+- Enabled via Flask-CORS extension
+- Allowed origins from environment variable
+- Defaults to `http://localhost:3000` for development
+- Supports multiple origins (comma-separated)
+
+## Consequences
+
+### Positive
+
+- **Modularity**: Blueprints provide clear separation of concerns; easy to locate and modify specific functionality
+- **Scalability**: New features can be added as new blueprints without touching existing code
+- **Predictability**: RESTful conventions make API intuitive for frontend developers
+- **Security**: JWT tokens provide stateless, secure authentication; refresh tokens minimize exposure
+- **Testability**: Blueprint isolation simplifies unit and integration testing
+- **Maintainability**: Consistent patterns reduce cognitive load; new developers can quickly understand structure
+- **Flexibility**: Environment-based configuration supports multiple deployment environments
+- **Standards Compliance**: Follows REST principles and HTTP specifications
+- **Frontend Integration**: JSON responses and CORS support seamless React integration
+- **Developer Experience**: Clear error messages and consistent responses improve DX
+- **Documentation**: Blueprint structure maps directly to API documentation
+
+### Negative
+
+- **Boilerplate**: RESTful patterns can create more code than ad-hoc approaches
+- **Token Management**: JWT requires careful handling on client-side (storage, refresh logic)
+- **Statelessness Limitations**: JWT tokens cannot be invalidated server-side without additional infrastructure (blacklist)
+- **Learning Curve**: Team must understand REST principles and Flask-JWT-Extended
+- **Verbosity**: Consistent error handling requires repetitive try-catch blocks
+- **Environment Complexity**: Multiple environment variables must be managed across environments
+- **CORS Configuration**: Incorrect CORS setup can block legitimate frontend requests
+- **Over-Engineering Risk**: Simple CRUD operations still require full REST implementation
+- **Token Expiration**: Short-lived access tokens require refresh logic in frontend
+
+## Alternatives Considered
+
+### 1. GraphQL API
+**Description**: Use GraphQL instead of REST for flexible, client-driven queries.
+
+**Pros**:
+- Clients request only needed fields (reduces over-fetching)
+- Single endpoint for all operations
+- Strong typing via GraphQL schema
+- Excellent tooling (GraphiQL, Apollo)
+
+**Cons**:
+- Higher learning curve for team
+- More complex server implementation
+- Caching strategies more difficult
+- Overkill for simple CRUD operations
+- Less standardized than REST
+- Python GraphQL libraries less mature than Flask
+
+**Rejection Reason**: REST is sufficient for current use cases. The flexibility of GraphQL is not needed, and the team has more experience with REST.
+
+### 2. Monolithic Flask Application (No Blueprints)
+**Description**: Define all routes in a single `app.py` file without blueprint separation.
+
+**Pros**:
+- Simpler initial setup
+- Fewer files to navigate
+- Direct route registration
+- Less boilerplate
+
+**Cons**:
+- Becomes unmanageable as application grows
+- Difficult to test specific modules
+- No clear separation of concerns
+- Hard to onboard new developers
+- Merge conflicts in single file
+
+**Rejection Reason**: Does not scale. Even with current scope (~15 endpoints), blueprints improve organization significantly.
+
+### 3. RPC-Style API (Function Calls)
+**Description**: Use function-like endpoints (e.g., `/api/create_project`, `/api/get_user`).
+
+**Pros**:
+- Intuitive for developers from RPC backgrounds
+- Clear action names
+- Simple to implement
+
+**Cons**:
+- Not RESTful (violates HTTP semantics)
+- Doesn't leverage HTTP methods
+- Less predictable for frontend developers
+- Poor caching behavior
+- Against web standards
+
+**Rejection Reason**: REST is the industry standard for web APIs. RPC-style APIs are harder to cache and don't follow HTTP best practices.
+
+### 4. Session-Based Authentication (Cookies)
+**Description**: Use Flask sessions with cookies instead of JWT tokens.
+
+**Pros**:
+- Server-side session control (can revoke immediately)
+- Simpler client-side (no token management)
+- Built into Flask
+- CSRF protection patterns well-established
+
+**Cons**:
+- Requires server-side session storage (Redis, database)
+- Stateful (harder to scale horizontally)
+- CORS complexity with credentials
+- Not suitable for mobile apps or microservices
+- Less flexible for multi-service architectures
+
+**Rejection Reason**: JWT is stateless and better suited for modern SPA architectures. Easier to scale and works well with React frontend.
+
+### 5. Flask-RESTful Extension
+**Description**: Use Flask-RESTful library for API resource classes.
+
+**Pros**:
+- Resource-based class structure
+- Built-in request parsing
+- Automatic HTTP method routing
+- Cleaner than raw blueprints for pure REST
+
+**Cons**:
+- Additional dependency
+- More opinionated structure
+- Learning curve for Flask-RESTful patterns
+- Less flexibility for non-REST endpoints
+- Project already established with blueprints
+
+**Rejection Reason**: Standard Flask blueprints provide sufficient structure. Flask-RESTful would be beneficial for a greenfield project, but switching now adds complexity without clear benefits.
+
+### 6. API Versioning from Start
+**Description**: Version API endpoints (e.g., `/api/v1/projects`, `/api/v2/projects`).
+
+**Pros**:
+- Allows breaking changes without affecting existing clients
+- Clear deprecation path
+- Industry best practice for public APIs
+
+**Cons**:
+- Premature optimization (no external API consumers yet)
+- Increased complexity
+- Duplicates code during transitions
+- More endpoints to document and test
+
+**Rejection Reason**: YAGNI (You Aren't Gonna Need It). API versioning adds complexity before it's needed. Can be added later if external API access is provided.
+
+---
+
+## Implementation References
+
+- Flask application setup: `backend/app.py:1-98`
+- Blueprint examples:
+  - Authentication: `backend/routes/auth.py:27`
+  - Projects: `backend/routes/projects.py:14`
+  - Analysis: `backend/routes/analysis.py:6`
+- JWT configuration: `backend/app.py:23-42`
+- CORS setup: `backend/app.py:13-15`
+- Error handling pattern: `backend/routes/projects.py:164-253`
+
+## Related ADRs
+
+- ADR-001: Amazon S3 for File Storage (file upload endpoints)
+- Future: ADR-003: Two-Token JWT Authentication Strategy (detailed authentication ADR)
+
+---
+
+## References
+
+- [RESTful API Design Best Practices](https://restfulapi.net/)
+- [Flask Blueprints Documentation](https://flask.palletsprojects.com/en/latest/blueprints/)
+- [Flask-JWT-Extended Documentation](https://flask-jwt-extended.readthedocs.io/)
+- [HTTP Status Code Definitions (RFC 7231)](https://tools.ietf.org/html/rfc7231#section-6)
+- API Documentation: `backend/API_DOCUMENTATION.md`


### PR DESCRIPTION
Added two ADRs documenting key architectural decisions:

1. ADR-001: Amazon S3 for File Storage
   - Documents decision to use S3 via boto3 for CSV file storage
   - Covers implementation details, security, and file organization
   - Evaluates alternatives (local filesystem, PostgreSQL BYTEA, etc.)

2. ADR-002: RESTful API Design with Flask Blueprints
   - Documents REST API architecture and design patterns
   - Covers blueprints, JWT authentication, response formats
   - Evaluates alternatives (GraphQL, monolithic app, RPC-style, etc.)

These ADRs provide context for future developers and document the rationale behind major architectural choices in the platform.