### PR TITLE
Add period-by-period DiD breakdown and include next_steps in AI interpretation

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -316,10 +316,21 @@ PARALLEL TRENDS ASSUMPTION:
         # Build minimal prompt (maximize room for response)
         q = f"Q: {causal_question}\n" if causal_question else ""
         
-        prompt = f"""Interpret causal results. {q}Data: {results_summary}{pt_info}
+        prompt = f"""You are a causal inference expert. Interpret these results and provide actionable recommendations.
+{q}Data: {results_summary}{pt_info}
 
-Return JSON only:
-{{"executive_summary":"2 sentences","parallel_trends_interpretation":"2 sentences","effect_size_interpretation":"2 sentences","statistical_interpretation":"2 sentences","limitations":["item1","item2"],"implications":["item1","item2"],"confidence_level":"high/medium/low","recommendation":"1 sentence"}}"""
+Return JSON only with these exact fields:
+{{
+  "executive_summary": "2-3 sentences explaining the main finding in plain language",
+  "parallel_trends_interpretation": "2 sentences on whether the parallel trends assumption holds",
+  "effect_size_interpretation": "2 sentences on the practical significance of the effect",
+  "statistical_interpretation": "2 sentences on statistical significance and confidence",
+  "limitations": ["limitation 1", "limitation 2", "limitation 3"],
+  "implications": ["what this means for practice 1", "what this means 2"],
+  "confidence_level": "high/medium/low",
+  "next_steps": ["specific actionable step 1", "specific actionable step 2", "specific actionable step 3"],
+  "recommendation": "1-2 sentence overall recommendation based on results"
+}}"""
         
         # Log prompt length for debugging
         response = self._call_gemini(prompt)
@@ -346,6 +357,7 @@ Return JSON only:
                 'limitations': interpretation.get('limitations', []),
                 'implications': interpretation.get('implications', []),
                 'confidence_level': interpretation.get('confidence_level', 'medium'),
+                'next_steps': interpretation.get('next_steps', []),
                 'recommendation': interpretation.get('recommendation', '')
             }
         except json.JSONDecodeError:
@@ -375,6 +387,7 @@ Return JSON only:
                 'limitations': partial_data.get('limitations', ['Response was truncated - incomplete data available']),
                 'implications': partial_data.get('implications', []),
                 'confidence_level': partial_data.get('confidence_level', 'unknown'),
+                'next_steps': partial_data.get('next_steps', []),
                 'recommendation': partial_data.get('recommendation', '')
             }
     

--- a/frontend/src/components/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard.tsx
@@ -155,9 +155,6 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
             {progressStatus.label}
             {progressStatus.method && ` • ${progressStatus.method}`}
           </span>
-          {project.current_step !== 'projects' && (
-            <span style={styles.continueHint}>Click to continue →</span>
-          )}
         </div>
       )}
       

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -445,7 +445,15 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                     
                     {/* Summary Header */}
                     <div style={styles.summaryHeader}>
-                        <h1 style={styles.pageTitle}>Analysis Results</h1>
+                        <div style={styles.summaryHeaderTop}>
+                            <h1 style={styles.pageTitle}>Analysis Results</h1>
+                            <button 
+                                style={styles.detailsToggleBtn}
+                                onClick={() => setShowDetails(!showDetails)}
+                            >
+                                {showDetails ? '▼' : '▶'} Statistical Details
+                            </button>
+                        </div>
                         <div style={styles.summaryCard}>
                             <p style={styles.summaryText}>
                                 {generateAISummary()}
@@ -457,9 +465,50 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                                 }}>
                                     Effect: {(results.results?.did_estimate || 0) > 0 ? '+' : ''}{formatNumber(results.results?.did_estimate, 2)}
                                     {(results.results?.is_significant || false) ? ' (significant)' : ' (not significant)'}
-                                    </span>
+                                </span>
                             </p>
                         </div>
+
+                        {/* Statistical Details (expandable) */}
+                        {showDetails && (
+                            <div style={styles.statisticalDetailsInline}>
+                                <div style={styles.detailsGrid}>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>Treatment Effect (DiD):</span>
+                                        <span style={styles.detailValue}>{formatNumber(results.results?.did_estimate, 2)}</span>
+                            </div>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>95% Confidence Interval:</span>
+                                        <span style={styles.detailValue}>
+                                            [{formatNumber(results.results?.confidence_interval?.lower, 2)}, {formatNumber(results.results?.confidence_interval?.upper, 2)}]
+                                    </span>
+                                    </div>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>p-value:</span>
+                                        <span style={styles.detailValue}>{formatNumber(results.results?.p_value, 4)}</span>
+                                    </div>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>Control Variables:</span>
+                                        <span style={styles.detailValue}>
+                                            {(results.parameters?.controls?.length || 0) > 0 
+                                                ? (results.parameters?.controls || []).join(', ') 
+                                                : 'None'
+                                            }
+                                    </span>
+                            </div>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>Total Observations:</span>
+                                        <span style={styles.detailValue}>{results.results?.statistics?.total_observations || 0}</span>
+                        </div>
+                                    <div style={styles.detailItem}>
+                                        <span style={styles.detailLabel}>Treated / Control Units:</span>
+                                        <span style={styles.detailValue}>
+                                            {results.results?.statistics?.treated_units || 0} / {results.results?.statistics?.control_units || 0}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                     </div>
 
         {/* NEW: Parallel Trends Assessment Section */}
@@ -1020,63 +1069,6 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                         )}
                     </div>
 
-                    {/* 3. THE TRUST & DETAILS SECTION */}
-                    <div style={styles.trustSection}>
-                        <h2 style={styles.sectionTitle}>Analysis Validity</h2>
-                        
-
-                        {/* Statistical Summary Toggle */}
-                        <div style={styles.detailsToggle}>
-                            <button 
-                                style={styles.toggleButton}
-                                onClick={() => setShowDetails(!showDetails)}
-                            >
-                                {showDetails ? '▼' : '▶'} View Statistical Details
-                            </button>
-                        </div>
-
-                        {showDetails && (
-                            <div style={styles.statisticalDetails}>
-                                <div style={styles.detailsGrid}>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>Treatment Effect (DiD):</span>
-                                        <span style={styles.detailValue}>{formatNumber(results.results?.did_estimate, 2)}</span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>95% Confidence Interval:</span>
-                                        <span style={styles.detailValue}>
-                                            [{formatNumber(results.results?.confidence_interval?.lower, 2)}, {formatNumber(results.results?.confidence_interval?.upper, 2)}]
-                                        </span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>p-value:</span>
-                                        <span style={styles.detailValue}>{formatNumber(results.results?.p_value, 4)}</span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>Control Variables Used:</span>
-                                        <span style={styles.detailValue}>
-                                            {(results.parameters?.controls?.length || 0) > 0 
-                                                ? (results.parameters?.controls || []).join(', ') 
-                                                : 'None'
-                                            }
-                                        </span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>Total Observations:</span>
-                                        <span style={styles.detailValue}>{results.results?.statistics?.total_observations || 0}</span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>Treated Units:</span>
-                                        <span style={styles.detailValue}>{results.results?.statistics?.treated_units || 0}</span>
-                                    </div>
-                                    <div style={styles.detailItem}>
-                                        <span style={styles.detailLabel}>Control Units:</span>
-                                        <span style={styles.detailValue}>{results.results?.statistics?.control_units || 0}</span>
-                                    </div>
-                                </div>
-                            </div>
-                        )}
-                    </div>
                 </div>
             </div>
             <BottomProgressBar
@@ -1116,11 +1108,34 @@ const styles = {
     marginBottom: '24px',
     boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)'
   },
+  summaryHeaderTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '12px'
+  },
   pageTitle: {
     fontSize: '24px',
     fontWeight: 'bold',
     color: '#043873',
-    margin: '0 0 12px 0'
+    margin: 0
+  },
+  detailsToggleBtn: {
+    backgroundColor: 'transparent',
+    border: '1px solid #dee2e6',
+    borderRadius: '6px',
+    padding: '8px 14px',
+    fontSize: '13px',
+    color: '#6c757d',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease'
+  },
+  statisticalDetailsInline: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '8px',
+    padding: '16px 20px',
+    marginTop: '16px',
+    borderTop: '1px solid #e9ecef'
   },
   summaryCard: {
     backgroundColor: '#f8fafc',

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -8,6 +8,26 @@ import NextStepsCard from './NextStepsCard';
 import { useAuth } from '../contexts/AuthContext';
 import { projectStateService } from '../services/projectStateService';
 
+// Download chart as PNG helper function
+const downloadChartAsPNG = (base64Data: string, filename: string) => {
+    const link = document.createElement('a');
+    link.href = `data:image/png;base64,${base64Data}`;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+interface PeriodStatistic {
+  period: string | number;
+  treatment_mean: number | null;
+  control_mean: number | null;
+  is_post_treatment: boolean;
+  is_treatment_start?: boolean;
+  period_effect: number | null;
+  counterfactual: number | null;
+}
+
 interface DiDResults {
   analysis_type: string;
   dataset_id: number;
@@ -44,6 +64,7 @@ interface DiDResults {
       outcome_mean_control_pre: number;
       outcome_mean_control_post: number;
     };
+    period_statistics?: PeriodStatistic[];
     interpretation: {
       effect_size: number;
       effect_direction: string;
@@ -59,7 +80,6 @@ interface DiDResults {
 }
 
 const ResultsPage: React.FC = () => {
-    console.log("=== RESULTS PAGE COMPONENT LOADED ===");
     const navigate = useNavigate();
     const location = useLocation();
     const { accessToken } = useAuth();
@@ -70,6 +90,9 @@ const ResultsPage: React.FC = () => {
     const [aiInterpretation, setAiInterpretation] = useState<ResultsInterpretation | null>(null);
     const [loadingAI, setLoadingAI] = useState(false);
     const [aiError, setAiError] = useState<string | null>(null);
+    const [showCode, setShowCode] = useState(false);
+    const [codeLanguage, setCodeLanguage] = useState<'python' | 'r'>('python');
+    const [selectedPeriod, setSelectedPeriod] = useState<string | number | null>(null);
     
     // Get project ID and dataset ID from navigation state or saved state
     const [projectId, setProjectId] = useState<number | null>((location.state as any)?.projectId || null);
@@ -85,18 +108,17 @@ const ResultsPage: React.FC = () => {
 
     useEffect(() => {
         const loadResults = async () => {
-            // First try to load from localStorage (fresh analysis)
-            console.log("=== LOADING RESULTS ===");
             const storedResults = localStorage.getItem('didAnalysisResults');
             
             // Track values to set at the end
             let loadedDatasetId: number | null = datasetId;
             let loadedProjectId: number | null = projectId;
+            let loadedResults: DiDResults | null = null;
             
             if (storedResults) {
                 try {
                     const parsedResults = JSON.parse(storedResults);
-                    console.log("Loaded results from localStorage", { dataset_id: parsedResults.dataset_id });
+                    loadedResults = parsedResults;
                     setResults(parsedResults);
                     // Set datasetId from results if not already set
                     if (parsedResults.dataset_id) {
@@ -116,10 +138,9 @@ const ResultsPage: React.FC = () => {
             // If no results from localStorage, try loading from project state
             if (!storedResults && loadedProjectId && accessToken) {
                 try {
-                    console.log("Trying to load saved results from project state...");
                     const project = await projectStateService.loadProject(loadedProjectId, accessToken);
                     if (project.lastResults) {
-                        console.log("Loaded results from project state");
+                        loadedResults = project.lastResults;
                         setResults(project.lastResults);
                         // Set datasetId from results
                         if (project.lastResults.dataset_id) {
@@ -134,6 +155,22 @@ const ResultsPage: React.FC = () => {
                     }
                 } catch (error) {
                     console.error('Error loading project state:', error);
+                }
+            }
+            
+            // Load stored AI interpretation if it matches the current analysis
+            if (loadedResults) {
+                try {
+                    const storedInterpretation = localStorage.getItem('aiInterpretation');
+                    if (storedInterpretation) {
+                        const parsed = JSON.parse(storedInterpretation);
+                        // Check if the interpretation matches the current analysis (by comparing DiD estimate)
+                        if (parsed.analysisKey === loadedResults.results?.did_estimate) {
+                            setAiInterpretation(parsed.interpretation);
+                        }
+                    }
+                } catch (error) {
+                    console.error('Error loading stored AI interpretation:', error);
                 }
             }
             
@@ -152,38 +189,12 @@ const ResultsPage: React.FC = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [projectId, accessToken, location.search]);
 
-    // Load AI interpretation when results are available
-    useEffect(() => {
-        console.log('AI useEffect triggered:', { 
-            hasResults: !!results, 
-            loading, 
-            hasAiInterpretation: !!aiInterpretation, 
-            loadingAI,
-            hasResultsResults: !!results?.results,
-            hasParameters: !!results?.parameters
-        });
-
+    // Function to load AI interpretation - only called when user clicks the button
         const loadAIInterpretation = async () => {
             if (!results?.results || !results?.parameters) {
-                console.log('AI: Skipping - missing results or parameters');
-                console.log('AI: results?.results =', results?.results);
-                console.log('AI: results?.parameters =', results?.parameters);
+            setAiError('Results or parameters not available');
                 return;
             }
-            
-            // Don't reload if we already have interpretation
-            if (aiInterpretation) {
-                console.log('AI: Skipping - already have interpretation');
-                return;
-            }
-            
-            console.log('AI: Starting interpretation...');
-            console.log('AI: Results data:', {
-                did_estimate: results.results.did_estimate,
-                p_value: results.results.p_value,
-                outcome: results.parameters.outcome,
-                treatment: results.parameters.treatment
-            });
             
             setLoadingAI(true);
             setAiError(null);
@@ -192,37 +203,28 @@ const ResultsPage: React.FC = () => {
                 const interpretation = await aiService.interpretResults(
                     results.results,
                     results.parameters,
-                    undefined, // causal_question (can be added later)
+                undefined,
                     'Difference-in-Differences'
                 );
-                console.log('AI: Interpretation received', interpretation);
                 setAiInterpretation(interpretation);
+            
+            // Store the interpretation in localStorage with a key tied to this analysis
+            try {
+                localStorage.setItem('aiInterpretation', JSON.stringify({
+                    analysisKey: results.results.did_estimate,
+                    interpretation: interpretation,
+                    timestamp: new Date().toISOString()
+                }));
+            } catch (storageError) {
+                console.error('Error saving AI interpretation to localStorage:', storageError);
+            }
             } catch (error: any) {
-                console.error('AI: Failed to load interpretation:', error);
-                console.error('AI: Error response:', error.response);
-                console.error('AI: Error status:', error.response?.status);
                 const errorMessage = error.response?.data?.error || error.message || 'Failed to load AI interpretation';
-                console.error('AI: Error details:', errorMessage);
                 setAiError(errorMessage);
             } finally {
                 setLoadingAI(false);
             }
         };
-
-        // Fetch when results are loaded and we're not already loading
-        if (results && !loading && !aiInterpretation && !loadingAI) {
-            console.log('AI: Conditions met, calling loadAIInterpretation');
-            loadAIInterpretation();
-        } else {
-            console.log('AI: Conditions not met, skipping:', {
-                hasResults: !!results,
-                notLoading: !loading,
-                noAiInterpretation: !aiInterpretation,
-                notLoadingAI: !loadingAI
-            });
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [results, loading]); // Intentionally not including aiInterpretation and loadingAI to avoid loops
 
     if (loading) {
         return (
@@ -235,18 +237,6 @@ const ResultsPage: React.FC = () => {
             </div>
         );
     }
-
-    // Debug the results structure
-    console.log("ResultsPage - Full results object:", results);
-    console.log("ResultsPage - results.results:", results?.results);
-    console.log("ResultsPage - results.parameters:", results?.parameters);
-    console.log("ResultsPage - results keys:", results ? Object.keys(results) : 'null');
-    console.log("ResultsPage - Condition check:", {
-        hasResults: !!results,
-        hasResultsResults: !!results?.results,
-        hasParameters: !!results?.parameters,
-        loading: loading
-    });
 
     // Show loading state while data is being loaded
     if (loading) {
@@ -274,8 +264,22 @@ const ResultsPage: React.FC = () => {
                     <div style={styles.mainContent}>
                         <div style={styles.resultsCard}>
                             <h2 style={styles.title}>No Results Found</h2>
-                            <p style={styles.message}>No analysisss results were found. Please run an analysis first.</p>
-                            <p style={styles.message}>Debug: hasResults={!!results}, hasResultsResults={!!results?.results}, hasParameters={!!results?.parameters}</p>
+                            <p style={styles.message}>No analysis results were found. Please run an analysis first.</p>
+                            <button 
+                                onClick={() => navigate('/variable-selection')}
+                                style={{
+                                    backgroundColor: '#043873',
+                                    color: 'white',
+                                    border: 'none',
+                                    borderRadius: '8px',
+                                    padding: '12px 24px',
+                                    fontSize: '16px',
+                                    cursor: 'pointer',
+                                    marginTop: '20px'
+                                }}
+                            >
+                                Go to Analysis Setup
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -303,27 +307,132 @@ const ResultsPage: React.FC = () => {
         }
     };
 
-    // Check parallel trends assumption (simplified)
-    const checkParallelTrends = () => {
-        // Add null checks for safety
-        if (!results?.results?.statistics) {
-            return false; // Default to failed if no statistics available
-        }
-        
-        const stats = results.results.statistics;
-        const treated_pre = stats.outcome_mean_treated_pre || 0;
-        const treated_post = stats.outcome_mean_treated_post || 0;
-        const control_pre = stats.outcome_mean_control_pre || 0;
-        const control_post = stats.outcome_mean_control_post || 0;
-        
-        // Calculate pre-treatment difference
-        const pre_diff = Math.abs(treated_pre - control_pre);
-        const post_diff = Math.abs(treated_post - control_post);
-        
-        // Simple heuristic: if pre-treatment difference is small relative to post-treatment difference
-        const ratio = pre_diff / (post_diff + 0.001); // Avoid division by zero
-        
-        return ratio < 0.5; // Passed if pre-treatment difference is less than half of post-treatment difference
+    // Generate Python code for the analysis
+    const generatePythonCode = () => {
+        if (!results?.parameters) return '';
+        const p = results.parameters;
+        return `# Difference-in-Differences Analysis
+# Generated by Causal Platform
+
+import pandas as pd
+import numpy as np
+import statsmodels.formula.api as smf
+import matplotlib.pyplot as plt
+
+# Load your data
+# df = pd.read_csv('your_data.csv')
+
+# Define variables
+outcome_var = '${p.outcome}'
+treatment_var = '${p.treatment}'
+time_var = '${p.time}'
+unit_var = '${p.unit}'
+treatment_start = '${p.treatment_start}'
+control_vars = ${JSON.stringify(p.controls || [])}
+
+# Create post-treatment indicator
+df['post'] = (df['${p.time}'] >= '${p.treatment_start}').astype(int)
+
+# Create treatment group indicator
+df['treated'] = df['${p.treatment}'].isin(${JSON.stringify(p.treatment_units || [])}).astype(int)
+
+# Create interaction term
+df['did'] = df['post'] * df['treated']
+
+# Run DiD regression
+formula = f"${p.outcome} ~ treated + post + did"
+${p.controls?.length ? `formula += " + " + " + ".join(${JSON.stringify(p.controls)})` : ''}
+model = smf.ols(formula, data=df).fit(cov_type='cluster', cov_kwds={'groups': df['${p.unit}']})
+
+# Print results
+print(model.summary())
+print(f"\\nDiD Estimate: {model.params['did']:.4f}")
+print(f"Standard Error: {model.bse['did']:.4f}")
+print(f"P-value: {model.pvalues['did']:.4f}")
+print(f"95% CI: [{model.conf_int().loc['did', 0]:.4f}, {model.conf_int().loc['did', 1]:.4f}]")
+
+# Visualization
+fig, ax = plt.subplots(figsize=(10, 6))
+treatment_means = df[df['treated'] == 1].groupby('${p.time}')['${p.outcome}'].mean()
+control_means = df[df['treated'] == 0].groupby('${p.time}')['${p.outcome}'].mean()
+
+ax.plot(treatment_means.index, treatment_means.values, 'b-o', label='Treatment Group')
+ax.plot(control_means.index, control_means.values, 'r-o', label='Control Group')
+ax.axvline(x='${p.treatment_start}', color='orange', linestyle='--', label='Treatment Start')
+ax.set_xlabel('${p.time}')
+ax.set_ylabel('${p.outcome}')
+ax.set_title('Difference-in-Differences Analysis')
+ax.legend()
+plt.tight_layout()
+plt.savefig('did_chart.png', dpi=300)
+plt.show()`;
+    };
+
+    // Generate R code for the analysis
+    const generateRCode = () => {
+        if (!results?.parameters) return '';
+        const p = results.parameters;
+        return `# Difference-in-Differences Analysis
+# Generated by Causal Platform
+
+library(tidyverse)
+library(fixest)
+library(ggplot2)
+
+# Load your data
+# df <- read.csv('your_data.csv')
+
+# Define variables
+outcome_var <- "${p.outcome}"
+treatment_var <- "${p.treatment}"
+time_var <- "${p.time}"
+unit_var <- "${p.unit}"
+treatment_start <- "${p.treatment_start}"
+treatment_units <- c(${(p.treatment_units || []).map(u => `"${u}"`).join(', ')})
+control_vars <- c(${(p.controls || []).map(c => `"${c}"`).join(', ')})
+
+# Create indicators
+df <- df %>%
+  mutate(
+    post = as.integer(${p.time} >= "${p.treatment_start}"),
+    treated = as.integer(${p.treatment} %in% treatment_units),
+    did = post * treated
+  )
+
+# Run DiD regression with clustered standard errors
+${p.controls?.length 
+  ? `model <- feols(${p.outcome} ~ treated + post + did + ${p.controls.join(' + ')} | ${p.unit}, data = df)` 
+  : `model <- feols(${p.outcome} ~ treated + post + did | ${p.unit}, data = df)`}
+
+# Print results
+summary(model)
+cat("\\nDiD Estimate:", coef(model)["did"], "\\n")
+cat("Standard Error:", se(model)["did"], "\\n")
+cat("P-value:", pvalue(model)["did"], "\\n")
+confint_did <- confint(model)["did", ]
+cat("95% CI: [", confint_did[1], ",", confint_did[2], "]\\n")
+
+# Visualization
+df_summary <- df %>%
+  group_by(${p.time}, treated) %>%
+  summarize(mean_outcome = mean(${p.outcome}, na.rm = TRUE), .groups = 'drop') %>%
+  mutate(group = ifelse(treated == 1, "Treatment", "Control"))
+
+ggplot(df_summary, aes(x = ${p.time}, y = mean_outcome, color = group, group = group)) +
+  geom_line(linewidth = 1) +
+  geom_point(size = 3) +
+  geom_vline(xintercept = "${p.treatment_start}", linetype = "dashed", color = "orange") +
+  labs(
+    title = "Difference-in-Differences Analysis",
+    x = "${p.time}",
+    y = "${p.outcome}",
+    color = "Group"
+  ) +
+  scale_color_manual(values = c("Treatment" = "#4F9CF9", "Control" = "#FF6B6B")) +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+
+ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
     };
 
     return (
@@ -394,7 +503,19 @@ const ResultsPage: React.FC = () => {
           {/* Visual Inspection Chart */}
           {(results.results as any)?.parallel_trends_test?.visual_chart && (
             <div style={styles.chartContainer}>
-              <h3>Pre-Treatment Trends</h3>
+              <div style={styles.chartHeader}>
+                <h3 style={styles.chartSubtitle}>Pre-Treatment Trends</h3>
+                <button
+                  onClick={() => downloadChartAsPNG(
+                    (results.results as any).parallel_trends_test.visual_chart,
+                    'parallel_trends_chart.png'
+                  )}
+                  style={styles.downloadButton}
+                  title="Download chart as PNG"
+                >
+                  ⬇️ Download PNG
+                </button>
+              </div>
               <img 
                 src={`data:image/png;base64,${(results.results as any).parallel_trends_test.visual_chart}`} 
                 alt="Pre-treatment trends comparison" 
@@ -410,7 +531,21 @@ const ResultsPage: React.FC = () => {
 
         {/* 2. THE DiD VISUALIZATION */}
         <div style={styles.visualizationSection}>
+            <div style={styles.chartHeader}>
             <h2 style={styles.sectionTitle}>What Happened Over Time</h2>
+                {(results.results as any)?.chart && (
+                    <button
+                        onClick={() => downloadChartAsPNG(
+                            (results.results as any).chart,
+                            'did_analysis_chart.png'
+                        )}
+                        style={styles.downloadButton}
+                        title="Download chart as PNG"
+                    >
+                        ⬇️ Download PNG
+                    </button>
+                )}
+            </div>
             <div style={styles.chartContainer}>
                 {(results.results as any)?.chart ? (
                     <div style={styles.realChartContainer}>
@@ -434,14 +569,336 @@ const ResultsPage: React.FC = () => {
             </div>
         </div>
 
-                    {/* AI INTERPRETATION SECTION - ALWAYS VISIBLE */}
+        {/* EFFECT SIZE BREAKDOWN - Period by Period */}
+        <div style={styles.effectBreakdownSection}>
+            <h2 style={styles.sectionTitle}>📊 Effect Size by Period</h2>
+            
+            {/* Period Selector */}
+            {results.results?.period_statistics && results.results.period_statistics.length > 0 ? (
+                <>
+                <div style={styles.periodSelectorContainer}>
+                    <label style={styles.periodSelectorLabel}>Select a period to see effect size:</label>
+                    <div style={styles.periodTabs}>
+                        {results.results.period_statistics.map((period, index) => (
+                            <button
+                                key={index}
+                                onClick={() => setSelectedPeriod(period.period)}
+                                style={{
+                                    ...styles.periodTab,
+                                    ...(selectedPeriod === period.period || (selectedPeriod === null && period.is_post_treatment && !period.is_treatment_start && 
+                                        results.results?.period_statistics?.filter(p => p.is_post_treatment && !p.is_treatment_start)[0]?.period === period.period) 
+                                        ? styles.periodTabActive : {}),
+                                    ...(period.is_post_treatment ? {} : styles.periodTabPre),
+                                    ...(period.is_treatment_start ? styles.periodTabTransition : {})
+                                }}
+                            >
+                                <span style={styles.periodTabLabel}>{period.period}</span>
+                                {period.is_treatment_start ? (
+                                    <span style={{...styles.periodTabBadge, backgroundColor: 'rgba(255, 193, 7, 0.3)', color: '#856404'}}>Start</span>
+                                ) : period.is_post_treatment ? (
+                                    <span style={styles.periodTabBadge}>Post</span>
+                                ) : null}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Period Detail Card */}
+                {(() => {
+                    const periodStats = results.results?.period_statistics || [];
+                    // Default to first post-treatment period that's not the transition year
+                    const postTreatmentPeriods = periodStats.filter(p => p.is_post_treatment && !p.is_treatment_start);
+                    const currentPeriod = selectedPeriod 
+                        ? periodStats.find(p => p.period === selectedPeriod) 
+                        : postTreatmentPeriods[0];
+                    
+                    if (!currentPeriod) return null;
+                    
+                    return (
+                        <div style={styles.periodDetailContainer}>
+                            {/* Period Header */}
+                            <div style={styles.periodHeader}>
+                                <h3 style={styles.periodTitle}>
+                                    {currentPeriod.is_treatment_start 
+                                        ? `⚡ Treatment Start: ${currentPeriod.period}`
+                                        : currentPeriod.is_post_treatment 
+                                            ? `📅 Period: ${currentPeriod.period}` 
+                                            : `📅 Pre-Treatment: ${currentPeriod.period}`}
+                                </h3>
+                                <span style={{
+                                    ...styles.periodTypeBadge,
+                                    backgroundColor: currentPeriod.is_treatment_start 
+                                        ? '#ffc107' 
+                                        : currentPeriod.is_post_treatment ? '#28a745' : '#6c757d'
+                                }}>
+                                    {currentPeriod.is_treatment_start 
+                                        ? 'Transition Year' 
+                                        : currentPeriod.is_post_treatment ? 'After Treatment' : 'Before Treatment'}
+                                </span>
+                            </div>
+
+                            {/* Transition Year Warning */}
+                            {currentPeriod.is_treatment_start && (
+                                <div style={styles.transitionWarning}>
+                                    <p><strong>⚠️ Transition Year</strong></p>
+                                    <p>This is the year when treatment began. Effect sizes are not calculated for the treatment start year because:</p>
+                                    <ul>
+                                        <li>Treatment may not be fully implemented</li>
+                                        <li>Effects may be partial or delayed</li>
+                                        <li>Including it could bias the estimates</li>
+                                    </ul>
+                                </div>
+                            )}
+
+                            {/* Values Comparison */}
+                            <div style={styles.periodValuesGrid}>
+                                <div style={styles.periodValueCard}>
+                                    <div style={styles.periodValueHeader}>
+                                        <span style={{...styles.groupDot, backgroundColor: '#4F9CF9'}}></span>
+                                        Treatment Group
+                                    </div>
+                                    <div style={{...styles.periodValueNumber, color: '#4F9CF9'}}>
+                                        {formatNumber(currentPeriod.treatment_mean, 2)}
+                                    </div>
+                                </div>
+                                
+                                <div style={styles.periodValueCard}>
+                                    <div style={styles.periodValueHeader}>
+                                        <span style={{...styles.groupDot, backgroundColor: '#FF6B6B'}}></span>
+                                        Control Group
+                                    </div>
+                                    <div style={{...styles.periodValueNumber, color: '#FF6B6B'}}>
+                                        {formatNumber(currentPeriod.control_mean, 2)}
+                                    </div>
+                                </div>
+
+                                {currentPeriod.is_post_treatment && !currentPeriod.is_treatment_start && currentPeriod.counterfactual && (
+                                    <div style={{...styles.periodValueCard, borderStyle: 'dashed'}}>
+                                        <div style={styles.periodValueHeader}>
+                                            <span style={{...styles.groupDot, backgroundColor: '#9CA3AF'}}></span>
+                                            Counterfactual
+                                        </div>
+                                        <div style={{...styles.periodValueNumber, color: '#9CA3AF'}}>
+                                            {formatNumber(currentPeriod.counterfactual, 2)}
+                                        </div>
+                                        <div style={styles.counterfactualNote}>
+                                            = Pre-treatment mean + Control's change from baseline
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* Effect Size for this Period */}
+                            {currentPeriod.is_post_treatment && !currentPeriod.is_treatment_start && currentPeriod.period_effect !== null && (
+                                <div style={styles.periodEffectCard}>
+                                    <div style={styles.periodEffectHeader}>
+                                        <span style={styles.periodEffectLabel}>🎯 Causal Effect in {currentPeriod.period}</span>
+                                    </div>
+                                    <div style={styles.periodEffectValue}>
+                                        {currentPeriod.period_effect >= 0 ? '+' : ''}
+                                        {formatNumber(currentPeriod.period_effect, 2)}
+                                    </div>
+                                    <div style={styles.periodEffectFormula}>
+                                        = Actual ({formatNumber(currentPeriod.treatment_mean, 2)}) − Counterfactual ({formatNumber(currentPeriod.counterfactual, 2)})
+                                    </div>
+                                </div>
+                            )}
+
+                            {!currentPeriod.is_post_treatment && (
+                                <div style={styles.preTreatmentNote}>
+                                    <p>📋 This is a <strong>pre-treatment period</strong>. Effect sizes are only calculated for post-treatment periods (excluding the treatment start year).</p>
+                                    <p>Treatment: {formatNumber(currentPeriod.treatment_mean, 2)} | Control: {formatNumber(currentPeriod.control_mean, 2)} | Diff: {formatNumber((currentPeriod.treatment_mean || 0) - (currentPeriod.control_mean || 0), 2)}</p>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })()}
+
+                {/* All Post-Treatment Effects Summary */}
+                {(() => {
+                    // Filter to post-treatment periods with effects, excluding the treatment start year
+                    const postPeriods = (results.results?.period_statistics || []).filter(
+                        p => p.is_post_treatment && !p.is_treatment_start && p.period_effect !== null
+                    );
+                    if (postPeriods.length === 0) return null;
+                    
+                    const maxEffect = Math.max(...postPeriods.map(p => Math.abs(p.period_effect || 0)), 0.1);
+                    
+                    return (
+                        <div style={styles.allEffectsContainer}>
+                            <h3 style={styles.allEffectsTitle}>📈 Causal Effect by Year (Excluding Treatment Start Year)</h3>
+                            <div style={styles.effectBarsContainer}>
+                                {postPeriods.map((period, index) => (
+                                    <div key={index} style={styles.effectBarGroup}>
+                                        <div style={styles.barLabel}>
+                                            <span style={{fontWeight: 'bold', color: '#333'}}>{period.period}</span>
+                                            <span style={{
+                                                ...styles.changeValue, 
+                                                color: (period.period_effect || 0) >= 0 ? '#28a745' : '#dc3545'
+                                            }}>
+                                                {(period.period_effect || 0) >= 0 ? '+' : ''}
+                                                {formatNumber(period.period_effect, 2)}
+                                            </span>
+                                        </div>
+                                        <div style={styles.barContainer}>
+                                            <div style={{
+                                                ...styles.bar,
+                                                width: `${Math.min(100, Math.abs((period.period_effect || 0) / maxEffect * 100))}%`,
+                                                backgroundColor: (period.period_effect || 0) >= 0 ? '#28a745' : '#dc3545'
+                                            }}></div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                            
+                            {/* Overall DiD */}
+                            <div style={{...styles.effectBarGroup, marginTop: '20px', paddingTop: '20px', borderTop: '2px solid #e9ecef'}}>
+                                <div style={styles.barLabel}>
+                                    <span style={{fontWeight: 'bold', color: '#043873'}}>📊 Overall Average (DiD Estimate)</span>
+                                    <span style={{...styles.changeValue, fontSize: '18px', color: '#043873'}}>
+                                        {(results.results?.did_estimate || 0) >= 0 ? '+' : ''}
+                                        {formatNumber(results.results?.did_estimate, 2)}
+                                    </span>
+                                </div>
+                            </div>
+                            
+                            <div style={styles.methodologyNote}>
+                                <p><strong>Methodology:</strong> Each period's effect = Actual treatment value − Counterfactual</p>
+                                <p>Counterfactual = Pre-treatment treatment mean + (Current control − Pre-treatment control mean)</p>
+                                <p>This assumes parallel trends: without intervention, treatment would follow control's trajectory.</p>
+                            </div>
+                        </div>
+                    );
+                })()}
+                </>
+            ) : (
+                /* Fallback to aggregate display if no period data */
+                <div style={styles.effectCardsContainer}>
+                    <div style={styles.effectCard}>
+                        <div style={styles.effectCardHeader}>
+                            <span style={styles.effectCardLabel}>Pre-Treatment Average</span>
+                            <span style={styles.periodBadge}>Baseline</span>
+                        </div>
+                        <div style={styles.effectComparison}>
+                            <div style={styles.groupValue}>
+                                <span style={styles.groupLabel}>Treatment</span>
+                                <span style={{...styles.groupNumber, color: '#4F9CF9'}}>
+                                    {formatNumber(results.results?.statistics?.outcome_mean_treated_pre, 1)}
+                                </span>
+                            </div>
+                            <div style={styles.vsIndicator}>vs</div>
+                            <div style={styles.groupValue}>
+                                <span style={styles.groupLabel}>Control</span>
+                                <span style={{...styles.groupNumber, color: '#FF6B6B'}}>
+                                    {formatNumber(results.results?.statistics?.outcome_mean_control_pre, 1)}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                    <div style={{...styles.effectCard, borderColor: '#28a745'}}>
+                        <div style={styles.effectCardHeader}>
+                            <span style={styles.effectCardLabel}>Post-Treatment Average</span>
+                            <span style={{...styles.periodBadge, backgroundColor: '#28a745'}}>After</span>
+                        </div>
+                        <div style={styles.effectComparison}>
+                            <div style={styles.groupValue}>
+                                <span style={styles.groupLabel}>Treatment</span>
+                                <span style={{...styles.groupNumber, color: '#4F9CF9'}}>
+                                    {formatNumber(results.results?.statistics?.outcome_mean_treated_post, 1)}
+                                </span>
+                            </div>
+                            <div style={styles.vsIndicator}>vs</div>
+                            <div style={styles.groupValue}>
+                                <span style={styles.groupLabel}>Control</span>
+                                <span style={{...styles.groupNumber, color: '#FF6B6B'}}>
+                                    {formatNumber(results.results?.statistics?.outcome_mean_control_post, 1)}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+
+        {/* CODE SECTION - Reproducible Analysis */}
+        <div style={styles.codeSection}>
+            <div style={styles.codeSectionHeader}>
+                <h2 style={styles.sectionTitle}>📝 Reproduce This Analysis</h2>
+                <button
+                    onClick={() => setShowCode(!showCode)}
+                    style={styles.codeToggleButton}
+                >
+                    {showCode ? '▼ Hide Code' : '▶ Show Code'}
+                </button>
+            </div>
+            
+            {showCode && (
+                <div style={styles.codeContent}>
+                    <p style={styles.codeDescription}>
+                        Use the code below to reproduce this analysis in your preferred environment.
+                    </p>
+                    
+                    {/* Language Tabs */}
+                    <div style={styles.languageTabs}>
+                        <button
+                            onClick={() => setCodeLanguage('python')}
+                            style={{
+                                ...styles.languageTab,
+                                ...(codeLanguage === 'python' ? styles.languageTabActive : {})
+                            }}
+                        >
+                            🐍 Python
+                        </button>
+                        <button
+                            onClick={() => setCodeLanguage('r')}
+                            style={{
+                                ...styles.languageTab,
+                                ...(codeLanguage === 'r' ? styles.languageTabActive : {})
+                            }}
+                        >
+                            📊 R
+                        </button>
+                    </div>
+                    
+                    {/* Code Block */}
+                    <div style={styles.codeBlock}>
+                        <div style={styles.codeBlockHeader}>
+                            <span style={styles.codeBlockTitle}>
+                                {codeLanguage === 'python' ? 'Python (statsmodels)' : 'R (fixest)'}
+                            </span>
+                            <button
+                                onClick={() => {
+                                    const code = codeLanguage === 'python' ? generatePythonCode() : generateRCode();
+                                    navigator.clipboard.writeText(code);
+                                    alert('Code copied to clipboard!');
+                                }}
+                                style={styles.copyButton}
+                            >
+                                📋 Copy Code
+                            </button>
+                        </div>
+                        <pre style={styles.codeText}>
+                            <code>{codeLanguage === 'python' ? generatePythonCode() : generateRCode()}</code>
+                        </pre>
+                    </div>
+                </div>
+            )}
+        </div>
+
+                    {/* AI INTERPRETATION SECTION */}
                     <div style={styles.aiSection}>
-                        <h2 style={styles.sectionTitle}>🤖 AI Interpretation</h2>
-                        <p style={{fontSize: '14px', color: '#666', marginBottom: '20px'}}>
-                            Debug: loadingAI={loadingAI ? 'true' : 'false'}, 
-                            hasInterpretation={aiInterpretation ? 'true' : 'false'}, 
-                            hasError={aiError ? 'true' : 'false'}
-                        </p>
+                        <div style={styles.aiSectionHeader}>
+                            <h2 style={styles.sectionTitle}>🤖 AI-Powered Interpretation</h2>
+                            {!aiInterpretation && !loadingAI && (
+                                <button 
+                                    onClick={loadAIInterpretation}
+                                    style={styles.getAiButton}
+                                    disabled={loadingAI}
+                                >
+                                    ✨ Get AI Recommendations
+                                </button>
+                            )}
+                        </div>
                         
                         {/* Loading State */}
                         {loadingAI && (
@@ -459,8 +916,7 @@ const ResultsPage: React.FC = () => {
                                 <button 
                                     onClick={() => {
                                         setAiError(null);
-                                        setLoadingAI(false);
-                                        setAiInterpretation(null);
+                                        loadAIInterpretation();
                                     }}
                                     style={{...styles.aiButton, marginTop: '10px', backgroundColor: '#6c757d'}}
                                 >
@@ -469,44 +925,15 @@ const ResultsPage: React.FC = () => {
                             </div>
                         )}
 
-                        {/* Show button if not loading and no result yet */}
+                        {/* Prompt to get AI interpretation */}
                         {!loadingAI && !aiInterpretation && !aiError && (
                             <div style={styles.aiPrompt}>
-                                <p>Get AI-powered insights about your analysis results.</p>
-                                <button 
-                                    onClick={() => {
-                                        console.log('AI: Manual trigger clicked');
-                                        console.log('AI: Results available?', !!results?.results);
-                                        console.log('AI: Parameters available?', !!results?.parameters);
-                                        if (results?.results && results?.parameters) {
-                                            setLoadingAI(true);
-                                            setAiError(null);
-                                            console.log('AI: Calling interpretResults...');
-                                            aiService.interpretResults(
-                                                results.results,
-                                                results.parameters,
-                                                undefined,
-                                                'Difference-in-Differences'
-                                            ).then(interpretation => {
-                                                console.log('AI: Manual interpretation received', interpretation);
-                                                setAiInterpretation(interpretation);
-                                                setLoadingAI(false);
-                                            }).catch(error => {
-                                                console.error('AI: Manual interpretation failed', error);
-                                                console.error('AI: Full error object:', error);
-                                                const errorMessage = error.response?.data?.error || error.message || 'Failed to load AI interpretation';
-                                                setAiError(errorMessage);
-                                                setLoadingAI(false);
-                                            });
-                                        } else {
-                                            console.error('AI: Cannot call - missing results or parameters');
-                                            setAiError('Results or parameters not available');
-                                        }
-                                    }}
-                                    style={styles.aiButton}
-                                >
-                                    Load AI Interpretation
-                                </button>
+                                <div style={styles.aiPromptIcon}>🤖</div>
+                                <h3 style={styles.aiPromptTitle}>Get Expert Analysis</h3>
+                                <p style={styles.aiPromptText}>
+                                    Click the button above to get AI-powered insights including executive summary, 
+                                    effect size interpretation, limitations, and actionable recommendations.
+                                </p>
                             </div>
                         )}
 
@@ -1278,5 +1705,486 @@ const styles = {
     cursor: 'pointer',
     marginTop: '20px',
     transition: 'background-color 0.2s'
+  },
+
+  // Download Button Styles
+  downloadButton: {
+    backgroundColor: '#043873',
+    color: 'white',
+    border: 'none',
+    borderRadius: '8px',
+    padding: '10px 16px',
+    fontSize: '14px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    transition: 'all 0.2s ease',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+  },
+  chartHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px',
+    flexWrap: 'wrap' as const,
+    gap: '15px'
+  },
+  chartSubtitle: {
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#495057',
+    margin: 0
+  },
+
+  // Code Section Styles
+  codeSection: {
+    backgroundColor: 'white',
+    borderRadius: '16px',
+    padding: '30px 40px',
+    marginBottom: '30px',
+    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
+    border: '1px solid #e9ecef'
+  },
+  codeSectionHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '10px'
+  },
+  codeToggleButton: {
+    backgroundColor: '#f8f9fa',
+    color: '#495057',
+    border: '1px solid #dee2e6',
+    borderRadius: '8px',
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease'
+  },
+  codeContent: {
+    marginTop: '20px'
+  },
+  codeDescription: {
+    fontSize: '15px',
+    color: '#666',
+    marginBottom: '20px',
+    lineHeight: '1.6'
+  },
+  languageTabs: {
+    display: 'flex',
+    gap: '10px',
+    marginBottom: '15px'
+  },
+  languageTab: {
+    backgroundColor: '#f8f9fa',
+    color: '#495057',
+    border: '2px solid #e9ecef',
+    borderRadius: '8px',
+    padding: '12px 24px',
+    fontSize: '14px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    transition: 'all 0.2s ease'
+  },
+  languageTabActive: {
+    backgroundColor: '#043873',
+    color: 'white',
+    borderColor: '#043873'
+  },
+  codeBlock: {
+    backgroundColor: '#1e1e1e',
+    borderRadius: '12px',
+    overflow: 'hidden',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
+  },
+  codeBlockHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 20px',
+    backgroundColor: '#2d2d2d',
+    borderBottom: '1px solid #3d3d3d'
+  },
+  codeBlockTitle: {
+    color: '#9cdcfe',
+    fontSize: '13px',
+    fontWeight: '600'
+  },
+  copyButton: {
+    backgroundColor: '#4F9CF9',
+    color: 'white',
+    border: 'none',
+    borderRadius: '6px',
+    padding: '8px 14px',
+    fontSize: '13px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px'
+  },
+  codeText: {
+    margin: 0,
+    padding: '20px',
+    fontSize: '13px',
+    lineHeight: '1.6',
+    color: '#d4d4d4',
+    overflow: 'auto',
+    maxHeight: '500px',
+    fontFamily: "'Fira Code', 'Consolas', 'Monaco', monospace"
+  },
+
+  // Effect Breakdown Section Styles
+  effectBreakdownSection: {
+    backgroundColor: 'white',
+    borderRadius: '16px',
+    padding: '40px',
+    marginBottom: '30px',
+    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)'
+  },
+  effectCardsContainer: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+    gap: '20px',
+    marginBottom: '30px'
+  },
+  effectCard: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '12px',
+    padding: '25px',
+    border: '2px solid #e9ecef',
+    transition: 'all 0.2s ease'
+  },
+  effectCardHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px'
+  },
+  effectCardLabel: {
+    fontSize: '16px',
+    fontWeight: 'bold',
+    color: '#495057'
+  },
+  periodBadge: {
+    backgroundColor: '#6c757d',
+    color: 'white',
+    padding: '4px 10px',
+    borderRadius: '12px',
+    fontSize: '11px',
+    fontWeight: '600',
+    textTransform: 'uppercase' as const
+  },
+  effectComparison: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '15px'
+  },
+  groupValue: {
+    textAlign: 'center' as const,
+    flex: 1
+  },
+  groupLabel: {
+    display: 'block',
+    fontSize: '12px',
+    color: '#6c757d',
+    marginBottom: '5px'
+  },
+  groupNumber: {
+    fontSize: '28px',
+    fontWeight: 'bold'
+  },
+  vsIndicator: {
+    fontSize: '14px',
+    color: '#adb5bd',
+    fontWeight: 'bold',
+    padding: '0 15px'
+  },
+  effectDiff: {
+    textAlign: 'center' as const,
+    fontSize: '14px',
+    color: '#495057',
+    padding: '10px',
+    backgroundColor: 'white',
+    borderRadius: '8px',
+    border: '1px solid #e9ecef'
+  },
+  effectBarSection: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '12px',
+    padding: '25px',
+    border: '1px solid #e9ecef'
+  },
+  effectBarTitle: {
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#495057',
+    margin: '0 0 20px 0'
+  },
+  effectBarsContainer: {
+    marginBottom: '20px'
+  },
+  effectBarGroup: {
+    marginBottom: '15px'
+  },
+  barLabel: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '8px',
+    fontSize: '14px'
+  },
+  changeValue: {
+    fontWeight: 'bold',
+    fontSize: '15px'
+  },
+  barContainer: {
+    backgroundColor: '#e9ecef',
+    borderRadius: '8px',
+    height: '20px',
+    overflow: 'hidden'
+  },
+  bar: {
+    height: '100%',
+    borderRadius: '8px',
+    transition: 'width 0.5s ease'
+  },
+  effectExplanation: {
+    backgroundColor: '#e3f2fd',
+    borderRadius: '8px',
+    padding: '15px 20px',
+    borderLeft: '4px solid #2196f3'
+  },
+
+  // Period Selector Styles
+  periodSelectorContainer: {
+    marginBottom: '25px'
+  },
+  periodSelectorLabel: {
+    display: 'block',
+    fontSize: '15px',
+    color: '#495057',
+    marginBottom: '12px',
+    fontWeight: '500'
+  },
+  periodTabs: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: '8px'
+  },
+  periodTab: {
+    padding: '10px 16px',
+    border: '2px solid #e9ecef',
+    borderRadius: '8px',
+    backgroundColor: '#f8f9fa',
+    cursor: 'pointer',
+    fontSize: '14px',
+    fontWeight: '500',
+    transition: 'all 0.2s ease',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: '4px',
+    minWidth: '70px'
+  },
+  periodTabActive: {
+    backgroundColor: '#043873',
+    color: 'white',
+    borderColor: '#043873'
+  },
+  periodTabPre: {
+    backgroundColor: '#f1f3f4',
+    borderColor: '#d1d5db',
+    color: '#6b7280'
+  },
+  periodTabLabel: {
+    fontSize: '14px',
+    fontWeight: '600'
+  },
+  periodTabBadge: {
+    fontSize: '10px',
+    padding: '2px 6px',
+    borderRadius: '10px',
+    backgroundColor: 'rgba(40, 167, 69, 0.2)',
+    color: '#28a745'
+  },
+  periodDetailContainer: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '12px',
+    padding: '25px',
+    marginBottom: '25px',
+    border: '1px solid #e9ecef'
+  },
+  periodHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px',
+    flexWrap: 'wrap' as const,
+    gap: '10px'
+  },
+  periodTitle: {
+    fontSize: '20px',
+    fontWeight: 'bold',
+    color: '#333',
+    margin: 0
+  },
+  periodTypeBadge: {
+    padding: '6px 12px',
+    borderRadius: '16px',
+    fontSize: '12px',
+    fontWeight: '600',
+    color: 'white'
+  },
+  periodValuesGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+    gap: '15px',
+    marginBottom: '20px'
+  },
+  periodValueCard: {
+    backgroundColor: 'white',
+    borderRadius: '10px',
+    padding: '18px',
+    border: '2px solid #e9ecef',
+    textAlign: 'center' as const
+  },
+  periodValueHeader: {
+    fontSize: '13px',
+    color: '#6c757d',
+    marginBottom: '8px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '6px'
+  },
+  groupDot: {
+    width: '10px',
+    height: '10px',
+    borderRadius: '50%',
+    display: 'inline-block'
+  },
+  periodValueNumber: {
+    fontSize: '32px',
+    fontWeight: 'bold'
+  },
+  counterfactualNote: {
+    fontSize: '11px',
+    color: '#9CA3AF',
+    marginTop: '4px'
+  },
+  periodEffectCard: {
+    backgroundColor: '#d4edda',
+    borderRadius: '12px',
+    padding: '20px',
+    textAlign: 'center' as const,
+    border: '2px solid #28a745'
+  },
+  periodEffectHeader: {
+    marginBottom: '10px'
+  },
+  periodEffectLabel: {
+    fontSize: '16px',
+    fontWeight: '600',
+    color: '#155724'
+  },
+  periodEffectValue: {
+    fontSize: '42px',
+    fontWeight: 'bold',
+    color: '#28a745',
+    marginBottom: '8px'
+  },
+  periodEffectFormula: {
+    fontSize: '13px',
+    color: '#155724',
+    fontFamily: 'monospace'
+  },
+  preTreatmentNote: {
+    backgroundColor: '#f1f3f4',
+    borderRadius: '8px',
+    padding: '15px 20px',
+    color: '#495057',
+    fontSize: '14px',
+    lineHeight: '1.6'
+  },
+  allEffectsContainer: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '12px',
+    padding: '25px',
+    border: '1px solid #e9ecef'
+  },
+  allEffectsTitle: {
+    fontSize: '18px',
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: '20px',
+    margin: '0 0 20px 0'
+  },
+  periodTabTransition: {
+    backgroundColor: '#fff3cd',
+    borderColor: '#ffc107',
+    color: '#856404'
+  },
+  transitionWarning: {
+    backgroundColor: '#fff3cd',
+    borderRadius: '8px',
+    padding: '15px 20px',
+    marginBottom: '20px',
+    border: '1px solid #ffc107',
+    color: '#856404'
+  },
+  methodologyNote: {
+    backgroundColor: '#f8f9fa',
+    borderRadius: '8px',
+    padding: '15px 20px',
+    marginTop: '20px',
+    fontSize: '13px',
+    color: '#6c757d',
+    lineHeight: '1.6',
+    borderLeft: '4px solid #6c757d'
+  },
+  aiSectionHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '20px',
+    flexWrap: 'wrap' as const,
+    gap: '15px'
+  },
+  getAiButton: {
+    backgroundColor: '#6366f1',
+    color: 'white',
+    border: 'none',
+    borderRadius: '10px',
+    padding: '14px 28px',
+    fontSize: '16px',
+    fontWeight: '600',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    boxShadow: '0 4px 14px rgba(99, 102, 241, 0.4)',
+    transition: 'all 0.2s ease'
+  },
+  aiPromptIcon: {
+    fontSize: '48px',
+    marginBottom: '15px'
+  },
+  aiPromptTitle: {
+    fontSize: '20px',
+    fontWeight: 'bold',
+    color: '#333',
+    margin: '0 0 10px 0'
+  },
+  aiPromptText: {
+    fontSize: '15px',
+    color: '#666',
+    lineHeight: '1.6',
+    maxWidth: '500px',
+    margin: '0 auto'
   }
 };

--- a/frontend/src/services/aiService.ts
+++ b/frontend/src/services/aiService.ts
@@ -8,6 +8,7 @@ export interface ResultsInterpretation {
   limitations: string[];
   implications: string[];
   confidence_level: string;
+  next_steps: string[];
   recommendation: string;
 }
 

--- a/frontend/src/services/projectStateService.ts
+++ b/frontend/src/services/projectStateService.ts
@@ -126,3 +126,4 @@ class ProjectStateService {
 export const projectStateService = new ProjectStateService();
 export default projectStateService;
 
+


### PR DESCRIPTION

- Add event-study style period_statistics to DiD analysis output (per-period treated/control means, counterfactuals, period_effect; treatment start marked as transition).
- Surface period_statistics in the API response.
- Expand LLM prompt and response handling to require and return next_steps; map next_steps through backend and update frontend typings.
- Minor frontend cleanup: remove unused “Click to continue” hint and whitespace fix.
- Backward compatible (additive changes).
- How to verify:
Run DiD endpoint — response includes period_statistics with expected fields.
Call interpret_results — response includes next_steps; frontend builds successfully.