### PR TITLE
Add results explanation + automatic group assignment

### DIFF
--- a/backend/services/ai_assistant.py
+++ b/backend/services/ai_assistant.py
@@ -229,6 +229,7 @@ Data Structure Analysis:
 """
 
         prompt = f"""You are a DiD expert. Validate this analysis setup before it runs.
+Note: Empty treatment/control units lists are VALID. In that case, the system automatically assigns groups based on the treatment variable and value.
 
 Analysis Parameters:
 - Outcome variable: {parameters.get('outcome')}

--- a/frontend/src/components/AIVariableSuggestions.tsx
+++ b/frontend/src/components/AIVariableSuggestions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import axios from 'axios';
 
 interface Suggestion {
@@ -31,7 +31,7 @@ const AIVariableSuggestions: React.FC<AIVariableSuggestionsProps> = ({
   const fetchSuggestions = async () => {
     setLoading(true);
     setError(null);
-    
+
     try {
       const response = await axios.post('/ai/suggest-variables', {
         schema_info: schemaInfo,
@@ -49,9 +49,9 @@ const AIVariableSuggestions: React.FC<AIVariableSuggestionsProps> = ({
 
   const applyAllSuggestions = () => {
     if (!suggestions) return;
-    
+
     const applied: any = {};
-    
+
     if (suggestions.outcome_suggestions?.[0]) {
       applied.outcome = suggestions.outcome_suggestions[0].column;
     }
@@ -64,7 +64,7 @@ const AIVariableSuggestions: React.FC<AIVariableSuggestionsProps> = ({
     if (suggestions.unit_suggestions?.[0]) {
       applied.unit = suggestions.unit_suggestions[0].column;
     }
-    
+
     onApplySuggestions(applied);
   };
 
@@ -75,10 +75,10 @@ const AIVariableSuggestions: React.FC<AIVariableSuggestionsProps> = ({
           <span style={styles.aiIcon}>🤖</span>
           <h3 style={styles.title}>AI Variable Assistant</h3>
         </div>
-        
+
         {!suggestions && !loading && (
-          <button 
-            onClick={fetchSuggestions} 
+          <button
+            onClick={fetchSuggestions}
             style={styles.getHelpButton}
             onMouseEnter={(e) => {
               e.currentTarget.style.backgroundColor = '#4f46e5';
@@ -156,8 +156,8 @@ const AIVariableSuggestions: React.FC<AIVariableSuggestionsProps> = ({
             <button onClick={applyAllSuggestions} style={styles.applyButton}>
               Apply All Suggestions
             </button>
-            <button 
-              onClick={() => setExpanded(false)} 
+            <button
+              onClick={() => setExpanded(false)}
               style={styles.dismissButton}
             >
               Dismiss
@@ -175,9 +175,9 @@ const SuggestionCard: React.FC<{
   icon: string;
 }> = ({ title, suggestions, icon }) => {
   if (!suggestions || suggestions.length === 0) return null;
-  
+
   const top = suggestions[0];
-  
+
   return (
     <div style={styles.suggestionCard}>
       <div style={styles.cardHeader}>
@@ -187,12 +187,12 @@ const SuggestionCard: React.FC<{
       <div style={styles.topSuggestion}>
         <span style={styles.columnName}>{top.column}</span>
         <div style={styles.confidenceBar}>
-          <div 
+          <div
             style={{
               ...styles.confidenceFill,
               width: `${top.confidence * 100}%`,
-              backgroundColor: top.confidence > 0.7 ? '#28a745' : 
-                              top.confidence > 0.4 ? '#ffc107' : '#dc3545'
+              backgroundColor: top.confidence > 0.7 ? '#28a745' :
+                top.confidence > 0.4 ? '#ffc107' : '#dc3545'
             }}
           />
         </div>

--- a/frontend/src/components/AnalysisValidationModal.tsx
+++ b/frontend/src/components/AnalysisValidationModal.tsx
@@ -92,18 +92,18 @@ const AnalysisValidationModal: React.FC<Props> = ({
               <div style={{
                 ...styles.statusBanner,
                 backgroundColor: validation.proceed_recommendation === 'proceed' ? '#d4edda' :
-                                validation.proceed_recommendation === 'review' ? '#fff3cd' : '#f8d7da'
+                  validation.proceed_recommendation === 'review' ? '#fff3cd' : '#f8d7da'
               }}>
-                <span style={styles.statusIcon}>
+                <span style={{ fontSize: '24px', marginRight: '10px' }}>
                   {validation.proceed_recommendation === 'proceed' ? '✅' :
-                   validation.proceed_recommendation === 'review' ? '⚠️' : '🛑'}
+                    validation.proceed_recommendation === 'review' ? '' : '🛑'}
                 </span>
                 <span style={styles.statusText}>
-                  {validation.proceed_recommendation === 'proceed' 
-                    ? 'Your analysis setup looks good!' 
+                  {validation.proceed_recommendation === 'proceed'
+                    ? 'Your analysis setup looks good!'
                     : validation.proceed_recommendation === 'review'
-                    ? 'Please review the warnings below'
-                    : 'Critical issues need to be fixed'}
+                      ? 'Please review the warnings below'
+                      : 'Critical issues need to be fixed'}
                 </span>
               </div>
 
@@ -163,14 +163,14 @@ const AnalysisValidationModal: React.FC<Props> = ({
         </div>
 
         <div style={styles.footer}>
-          <button 
-            onClick={onCancel} 
+          <button
+            onClick={onCancel}
             style={styles.cancelButton}
             disabled={runningAnalysis}
           >
             Go Back & Edit
           </button>
-          <button 
+          <button
             onClick={handleRunClick}
             disabled={loading || runningAnalysis || validation?.proceed_recommendation === 'stop'}
             style={{

--- a/frontend/src/components/ResultsPage.tsx
+++ b/frontend/src/components/ResultsPage.tsx
@@ -152,7 +152,6 @@ const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => {
 };
 
 const ResultsPage: React.FC = () => {
-  const navigate = useNavigate();
   const location = useLocation();
   const { accessToken } = useAuth();
   const { currentStep, steps, goToPreviousStep, goToNextStep, navigateToStep } = useProgressStep();
@@ -168,6 +167,8 @@ const ResultsPage: React.FC = () => {
   const [showCheck1Details, setShowCheck1Details] = useState(false);
   const [showCheck2Details, setShowCheck2Details] = useState(false);
   const [showDidCalculationDetails, setShowDidCalculationDetails] = useState(false);
+  const [showOutcomeExplanation, setShowOutcomeExplanation] = useState(false);
+  const [showStatsExplanation, setShowStatsExplanation] = useState(false);
   const [aiSidebarWidth, setAiSidebarWidth] = useState(480); // Default width in pixels
   const [isResizing, setIsResizing] = useState(false);
   const [isAiSidebarCollapsed, setIsAiSidebarCollapsed] = useState(false);
@@ -178,7 +179,7 @@ const ResultsPage: React.FC = () => {
   const [chatInput, setChatInput] = useState('');
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
-  const [recommendedQuestions, setRecommendedQuestions] = useState<string[]>([
+  const [recommendedQuestions] = useState<string[]>([
     "What is the parallel trends assumption?",
     "How do I interpret my DiD estimate?",
     "What are the limitations of this analysis?"
@@ -884,10 +885,164 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                           style={styles.realChart}
                         />
                       )}
-                      <div style={styles.chartNote}>
-                        The blue line represents the treatment group,
-                        the red line represents the control group, and the dashed line shows what would have happened
-                        to the treatment group without the intervention (counterfactual).
+
+                      {/* Foldable Helper Section for Reading the Chart */}
+                      <div style={{ marginTop: '24px', width: '100%' }}>
+                        <button
+                          onClick={() => setShowOutcomeExplanation(!showOutcomeExplanation)}
+                          style={{
+                            width: '100%',
+                            padding: '12px 16px',
+                            backgroundColor: '#f8f9fa',
+                            border: '1px solid #dee2e6',
+                            borderRadius: '8px',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            fontSize: '16px',
+                            fontWeight: '600',
+                            color: '#043873',
+                            transition: 'background-color 0.2s',
+                            boxSizing: 'border-box'
+                          }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor = '#e9ecef';
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor = '#f8f9fa';
+                          }}
+                        >
+                          <span>How to read this chart</span>
+                          <span>{showOutcomeExplanation ? '▲' : '▼'}</span>
+                        </button>
+
+                        {showOutcomeExplanation && (
+                          <div style={{
+                            marginTop: '0',
+                            padding: '24px',
+                            backgroundColor: '#ffffff',
+                            borderRadius: '0 0 8px 8px',
+                            border: '1px solid #dee2e6',
+                            borderTop: 'none',
+                            boxSizing: 'border-box',
+                            textAlign: 'left',
+                            fontSize: '15px',
+                            lineHeight: '1.7',
+                            color: '#1e293b' // Darker base color
+                          }}>
+                            <div style={{ marginBottom: '24px' }}>
+                              <h4 style={{ margin: '0 0 12px 0', color: '#0f172a', fontSize: '16px', fontWeight: '700' }}>
+                                Counterfactual (Dashed Line)
+                              </h4>
+                              <p style={{ margin: '0 0 12px 0' }}>
+                                The dashed line shows: <strong style={{ color: '#0f172a' }}>"What would have happened without the intervention?"</strong>
+                              </p>
+                              <p style={{ margin: '0 0 16px 0' }}>
+                                Think of it like a parallel universe where nothing changed. We estimate this by assuming both groups would have followed the same trend if there was no intervention.
+                              </p>
+
+                              <div style={{ marginBottom: '20px' }}>
+                                <strong style={{ color: '#334155', fontSize: '13px', display: 'block', marginBottom: '8px', textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: '700' }}>
+                                  How we calculate it:
+                                </strong>
+                                <ol style={{ margin: '0 0 0 24px', padding: 0 }}>
+                                  <li style={{ marginBottom: '12px' }}>
+                                    <strong style={{ color: '#0f172a' }}>Calculate the Initial Gap:</strong>
+                                    <div style={{ fontSize: '14px', color: '#334155', marginTop: '4px' }}>
+                                      How different were the two groups before the treatment? (Treatment Pre - Control Pre)
+                                    </div>
+                                  </li>
+                                  <li>
+                                    <strong style={{ color: '#0f172a' }}>Add the Control Group's Current Outcome:</strong>
+                                    <div style={{ fontSize: '14px', color: '#334155', marginTop: '4px' }}>
+                                      We assume this initial gap would have stayed the same over time.
+                                    </div>
+                                  </li>
+                                </ol>
+                              </div>
+
+                              <div style={{
+                                marginTop: '16px',
+                                backgroundColor: '#f8fafc',
+                                padding: '24px',
+                                borderRadius: '8px',
+                                border: '1px solid #e2e8f0',
+                                boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)'
+                              }}>
+                                <strong style={{ color: '#334155', fontSize: '13px', display: 'block', marginBottom: '16px', textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: '700' }}>
+                                  Formula breakdown
+                                </strong>
+                                <div style={{ fontFamily: "'Fira Code', 'Consolas', monospace", fontSize: '13px', color: '#334155', lineHeight: '1.8' }}>
+                                  <div style={{
+                                    marginTop: '0',
+                                    fontWeight: '600',
+                                    color: '#0f172a',
+                                    padding: '20px',
+                                    backgroundColor: '#e2e8f0',
+                                    borderRadius: '6px',
+                                    display: 'block',
+                                    border: '1px solid #cbd5e1',
+                                    marginBottom: '16px',
+                                    overflowX: 'auto'
+                                  }}>
+                                    <div style={{ display: 'flex', alignItems: 'baseline', flexWrap: 'wrap', gap: '8px' }}>
+                                      <span>Counterfactual</span>
+                                      <span>=</span>
+                                      <span style={{ color: '#0369a1' }}>(Treatment_Pre - Control_Pre)</span>
+                                      <span>+</span>
+                                      <span style={{ color: '#059669' }}>Control_Post</span>
+                                    </div>
+                                    <div style={{
+                                      fontSize: '11px',
+                                      fontWeight: 'normal',
+                                      marginTop: '8px',
+                                      color: '#475569',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      fontFamily: 'sans-serif'
+                                    }}>
+                                      {/* Spacer for Counterfactual = */}
+                                      <div style={{ width: '135px', flexShrink: 0 }}></div>
+                                      {/* Alignment for Initial Gap */}
+                                      <div style={{ width: '220px', textAlign: 'center', borderTop: '1px solid #94a3b8', marginTop: '-8px', paddingTop: '4px' }}>
+                                        Initial Gap
+                                      </div>
+                                      {/* Spacer for + */}
+                                      <div style={{ width: '25px', flexShrink: 0 }}></div>
+                                      {/* Alignment for Trend */}
+                                      <div style={{ width: '100px', textAlign: 'center', borderTop: '1px solid #94a3b8', marginTop: '-8px', paddingTop: '4px' }}>
+                                        Trend
+                                      </div>
+                                    </div>
+                                  </div>
+
+                                  <div style={{ fontSize: '14px', marginTop: '16px', lineHeight: '1.6' }}>
+                                    <strong style={{ color: '#0f172a' }}>Core Assumption:</strong> The counterfactual outcome for the treated group is that it would have maintained the same pre-treatment difference (<span style={{ color: '#0369a1', fontWeight: '600' }}>Initial Gap</span>) relative to the control group, even after the general time trend.
+                                  </div>
+                                </div>
+                              </div>
+
+                              <p style={{ marginTop: '20px', color: '#334155', fontStyle: 'italic', fontSize: '15px', borderLeft: '3px solid #cbd5e1', paddingLeft: '16px', marginLeft: '4px' }}>
+                                The gap between the actual treatment outcome (solid blue) and this counterfactual line (dashed) is the estimated effect of the intervention.
+                              </p>
+                            </div>
+
+                            <div>
+                              <h4 style={{ margin: '0 0 12px 0', color: '#0f172a', fontSize: '16px', fontWeight: '700' }}>
+                                Effect Size (Vertical Distance)
+                              </h4>
+                              <ul style={{ margin: '0 0 0 24px', padding: 0 }}>
+                                <li style={{ marginBottom: '8px' }}>
+                                  <strong style={{ color: '#2563eb' }}>Positive Effect:</strong> The solid blue line is higher than the dashed line.
+                                </li>
+                                <li>
+                                  <strong style={{ color: '#dc2626' }}>Negative Effect:</strong> The solid blue line is lower than the dashed line.
+                                </li>
+                              </ul>
+                            </div>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -1046,6 +1201,85 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
 
                         <div style={{ marginTop: '12px', fontSize: '13px', color: '#666', fontStyle: 'italic', textAlign: 'right' }}>
                           * 'Significant' means the result is likely not due to chance. The 95% CI shows the likely range of the true effect.
+                        </div>
+
+                        {/* Statistical Terms Explanation - New Section */}
+                        <div style={{ marginTop: '24px', marginBottom: '10px' }}>
+                          <button
+                            onClick={() => setShowStatsExplanation(!showStatsExplanation)}
+                            style={{
+                              width: '100%',
+                              padding: '12px 16px',
+                              backgroundColor: '#f8f9fa',
+                              border: '1px solid #dee2e6',
+                              borderRadius: '8px',
+                              cursor: 'pointer',
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              fontSize: '16px',
+                              fontWeight: '600',
+                              color: '#043873',
+                              transition: 'background-color 0.2s'
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.backgroundColor = '#e9ecef';
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.backgroundColor = '#f8f9fa';
+                            }}
+                            type="button"
+                          >
+                            <span>How to read these statistics</span>
+                            <span>{showStatsExplanation ? '▲' : '▼'}</span>
+                          </button>
+
+                          {showStatsExplanation && (
+                            <div style={{
+                              marginTop: '0',
+                              padding: '24px',
+                              backgroundColor: '#ffffff',
+                              borderRadius: '0 0 8px 8px',
+                              border: '1px solid #dee2e6',
+                              borderTop: 'none',
+                              boxSizing: 'border-box',
+                              textAlign: 'left',
+                              fontSize: '15px',
+                              lineHeight: '1.7',
+                              color: '#1e293b'
+                            }}>
+                              <div style={{ marginBottom: '20px' }}>
+                                <h4 style={{ margin: '0 0 8px 0', color: '#0f172a', fontSize: '16px', fontWeight: '700' }}>
+                                  P-Value
+                                </h4>
+                                <p style={{ margin: 0, color: '#334155' }}>
+                                  The probability that the observed effect happened by random chance. A low p-value (typically <strong>&lt; 0.05</strong>) suggests the result is real and not just noise.
+                                </p>
+                              </div>
+
+                              <div style={{ marginBottom: '20px' }}>
+                                <h4 style={{ margin: '0 0 8px 0', color: '#0f172a', fontSize: '16px', fontWeight: '700' }}>
+                                  Statistical Significance
+                                </h4>
+                                <p style={{ margin: 0, color: '#334155' }}>
+                                  A result is "statistically significant" when the p-value is low enough (typically &lt; 0.05) to trust that the intervention had a real effect.
+                                </p>
+                              </div>
+
+                              <div>
+                                <h4 style={{ margin: '0 0 8px 0', color: '#0f172a', fontSize: '16px', fontWeight: '700' }}>
+                                  95% Confidence Interval (CI)
+                                </h4>
+                                <p style={{ margin: 0, color: '#334155' }}>
+                                  This range gives you an idea of the precision of the estimate. We are 95% confident that the true effect lies within this range.
+                                </p>
+                                <ul style={{ margin: '8px 0 0 24px', padding: 0, color: '#334155' }}>
+                                  <li>If the interval <strong>does not cross zero</strong> (e.g., 2.5 to 5.8), the result is statistically significant.</li>
+                                  <li>If it <strong>crosses zero</strong> (e.g., -1.2 to 3.4), we generally cannot claim a significant effect.</li>
+                                </ul>
+                              </div>
+                            </div>
+                          )}
                         </div>
 
                         {/* How DiD was calculated - Collapsible */}

--- a/frontend/src/components/VariableSelectionPage.tsx
+++ b/frontend/src/components/VariableSelectionPage.tsx
@@ -208,14 +208,14 @@ const VariableSelectionPage: React.FC = () => {
       case 1: return !!selection.outcome;
       case 2: return !!selection.treatment && !!selection.treatment_value;
       case 3: return !!selection.time && !!selection.treatment_start && !!selection.start_period && !!selection.end_period;
-      case 4: return !!selection.unit;
-      case 5: return !!selection.treatment_units.length && !!selection.control_units.length;
+      case 4: return !!selection.unit; // Required: unit selection
+      case 5: return true; // Optional: manual group assignment
       case 6: return true; // Optional control variables card
       default: return false;
     }
   };
 
-  const canProceed = isCardComplete(1) && isCardComplete(2) && isCardComplete(3) && isCardComplete(4) && isCardComplete(5);
+  const canProceed = isCardComplete(1) && isCardComplete(2) && isCardComplete(3) && isCardComplete(4) && isCardComplete(5) && isCardComplete(6);
 
   // Resize handlers for AI sidebar
   useEffect(() => {
@@ -733,16 +733,16 @@ ALWAYS BE PRECISE: Use the exact variable names from the parameters, never subst
                 </div>
 
 
-                {/* Card 4: Select Treatment and Control Units */}
+                {/* Card 4: Select Unit Variable */}
                 <div style={styles.card}>
                   <div style={styles.cardHeader}>
                     <div style={styles.cardNumber}>4</div>
                     <div style={styles.cardTitle}>
                       <HelpTooltip concept="unit of analysis">
-                        Select Treatment and Control Groups
+                        Select Unit Variable
                       </HelpTooltip>
                     </div>
-                    <div style={styles.optionalBadge}>Optional</div>
+                    <div style={styles.requiredBadge}>Required</div>
                   </div>
                   <p style={styles.helperText}>
                     Which column identifies your individuals or groups? Select the column that uniquely identifies each unit being tracked over time.
@@ -759,132 +759,148 @@ ALWAYS BE PRECISE: Use the exact variable names from the parameters, never subst
                     placeholder="Search and select unit column..."
                     style={styles.select}
                   />
-                  <p style={styles.helperText}>
-                    Choose which specific {selection.unit} values should be in your treatment group and which should be in your control group.
-                  </p>
-
-                  {/* Get unique values for the unit variable */}
-                  {(() => {
-                    const unitVariable = variables.find(v => v.name === selection.unit);
-                    const unitValues = unitVariable?.unique_values || [];
-                    return (
-                      <div style={styles.unitSelectionContainer}>
-                        {/* Treatment Units */}
-                        <div style={styles.unitGroup}>
-                          <h4 style={styles.unitGroupTitle}>Treatment Group Units</h4>
-                          <p style={styles.unitGroupDescription}>
-                            Select which {selection.unit} values should receive the treatment:
-                          </p>
-                          <div style={styles.searchableDropdownContainer}>
-                            <SearchableDropdown
-                              options={unitValues.map(value => ({
-                                value: value,
-                                label: value
-                              }))}
-                              value=""
-                              onChange={(value) => {
-                                // Add the selected value to the treatment units if it's not already there
-                                if (value && !selection.treatment_units.includes(value)) {
-                                  setSelection(prev => ({
-                                    ...prev,
-                                    treatment_units: [...prev.treatment_units, value],
-                                    control_units: prev.control_units.filter(u => u !== value)
-                                  }));
-                                }
-                              }}
-                              placeholder="Search and select treatment units..."
-                              style={styles.select}
-                            />
-                            {/* Show selected treatment units */}
-                            {selection.treatment_units.length > 0 && (
-                              <div style={styles.selectedUnits}>
-                                <p style={styles.selectedUnitsLabel}>Selected Treatment Units:</p>
-                                <div style={styles.selectedUnitsList}>
-                                  {selection.treatment_units.map(unit => (
-                                    <span key={unit} style={styles.selectedUnitTag}>
-                                      {unit}
-                                      <button
-                                        type="button"
-                                        style={styles.removeUnitButton}
-                                        onClick={() => {
-                                          setSelection(prev => ({
-                                            ...prev,
-                                            treatment_units: prev.treatment_units.filter(u => u !== unit)
-                                          }));
-                                        }}
-                                      >
-                                        ×
-                                      </button>
-                                    </span>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-
-                        {/* Control Units */}
-                        <div style={styles.unitGroup}>
-                          <h4 style={styles.unitGroupTitle}>Control Group Units</h4>
-                          <p style={styles.unitGroupDescription}>
-                            Select which {selection.unit} values should be in the control group:
-                          </p>
-                          <div style={styles.searchableDropdownContainer}>
-                            <SearchableDropdown
-                              options={unitValues.map(value => ({
-                                value: value,
-                                label: value
-                              }))}
-                              value=""
-                              onChange={(value) => {
-                                // Add the selected value to the control units if it's not already there
-                                if (value && !selection.control_units.includes(value)) {
-                                  setSelection(prev => ({
-                                    ...prev,
-                                    control_units: [...prev.control_units, value],
-                                    treatment_units: prev.treatment_units.filter(u => u !== value)
-                                  }));
-                                }
-                              }}
-                              placeholder="Search and select control units..."
-                              style={styles.select}
-                            />
-                            {/* Show selected control units */}
-                            {selection.control_units.length > 0 && (
-                              <div style={styles.selectedUnits}>
-                                <p style={styles.selectedUnitsLabel}>Selected Control Units:</p>
-                                <div style={styles.selectedUnitsList}>
-                                  {selection.control_units.map(unit => (
-                                    <span key={unit} style={styles.selectedUnitTag}>
-                                      {unit}
-                                      <button
-                                        type="button"
-                                        style={styles.removeUnitButton}
-                                        onClick={() => {
-                                          setSelection(prev => ({
-                                            ...prev,
-                                            control_units: prev.control_units.filter(u => u !== unit)
-                                          }));
-                                        }}
-                                      >
-                                        ×
-                                      </button>
-                                    </span>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })()}
                 </div>
 
-                {/* Card 5: Control Variables */}
+                {/* Card 5: Manual Treatment and Control Group Assignment */}
+                {selection.unit && (
+                  <div style={styles.card}>
+                    <div style={styles.cardHeader}>
+                      <div style={styles.cardNumber}>5</div>
+                      <div style={styles.cardTitle}>
+                        <HelpTooltip concept="manual group assignment">
+                          Manual Treatment and Control Group Assignment
+                        </HelpTooltip>
+                      </div>
+                      <div style={styles.optionalBadge}>Optional</div>
+                    </div>
+                    <p style={styles.helperText}>
+                      Choose which specific {selection.unit} values should be in your treatment group and which should be in your control group.
+                      If left empty, we will automatically assign groups based on your treatment variable.
+                    </p>
+
+                    {/* Get unique values for the unit variable */}
+                    {(() => {
+                      const unitVariable = variables.find(v => v.name === selection.unit);
+                      const unitValues = unitVariable?.unique_values || [];
+                      return (
+                        <div style={styles.unitSelectionContainer}>
+                          {/* Treatment Units */}
+                          <div style={styles.unitGroup}>
+                            <h4 style={styles.unitGroupTitle}>Treatment Group Units</h4>
+                            <p style={styles.unitGroupDescription}>
+                              Select which {selection.unit} values should receive the treatment:
+                            </p>
+                            <div style={styles.searchableDropdownContainer}>
+                              <SearchableDropdown
+                                options={unitValues.map(value => ({
+                                  value: value,
+                                  label: value
+                                }))}
+                                value=""
+                                onChange={(value) => {
+                                  // Add the selected value to the treatment units if it's not already there
+                                  if (value && !selection.treatment_units.includes(value)) {
+                                    setSelection(prev => ({
+                                      ...prev,
+                                      treatment_units: [...prev.treatment_units, value],
+                                      control_units: prev.control_units.filter(u => u !== value)
+                                    }));
+                                  }
+                                }}
+                                placeholder="Search and select treatment units..."
+                                style={styles.select}
+                              />
+                              {/* Show selected treatment units */}
+                              {selection.treatment_units.length > 0 && (
+                                <div style={styles.selectedUnits}>
+                                  <p style={styles.selectedUnitsLabel}>Selected Treatment Units:</p>
+                                  <div style={styles.selectedUnitsList}>
+                                    {selection.treatment_units.map(unit => (
+                                      <span key={unit} style={styles.selectedUnitTag}>
+                                        {unit}
+                                        <button
+                                          type="button"
+                                          style={styles.removeUnitButton}
+                                          onClick={() => {
+                                            setSelection(prev => ({
+                                              ...prev,
+                                              treatment_units: prev.treatment_units.filter(u => u !== unit)
+                                            }));
+                                          }}
+                                        >
+                                          ×
+                                        </button>
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+
+                          {/* Control Units */}
+                          <div style={styles.unitGroup}>
+                            <h4 style={styles.unitGroupTitle}>Control Group Units</h4>
+                            <p style={styles.unitGroupDescription}>
+                              Select which {selection.unit} values should be in the control group:
+                            </p>
+                            <div style={styles.searchableDropdownContainer}>
+                              <SearchableDropdown
+                                options={unitValues.map(value => ({
+                                  value: value,
+                                  label: value
+                                }))}
+                                value=""
+                                onChange={(value) => {
+                                  // Add the selected value to the control units if it's not already there
+                                  if (value && !selection.control_units.includes(value)) {
+                                    setSelection(prev => ({
+                                      ...prev,
+                                      control_units: [...prev.control_units, value],
+                                      treatment_units: prev.treatment_units.filter(u => u !== value)
+                                    }));
+                                  }
+                                }}
+                                placeholder="Search and select control units..."
+                                style={styles.select}
+                              />
+                              {/* Show selected control units */}
+                              {selection.control_units.length > 0 && (
+                                <div style={styles.selectedUnits}>
+                                  <p style={styles.selectedUnitsLabel}>Selected Control Units:</p>
+                                  <div style={styles.selectedUnitsList}>
+                                    {selection.control_units.map(unit => (
+                                      <span key={unit} style={styles.selectedUnitTag}>
+                                        {unit}
+                                        <button
+                                          type="button"
+                                          style={styles.removeUnitButton}
+                                          onClick={() => {
+                                            setSelection(prev => ({
+                                              ...prev,
+                                              control_units: prev.control_units.filter(u => u !== unit)
+                                            }));
+                                          }}
+                                        >
+                                          ×
+                                        </button>
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })()}
+                  </div>
+                )}
+
+                {/* Card 6: Control Variables */}
                 <div style={styles.card}>
                   <div style={styles.cardHeader}>
-                    <div style={styles.cardNumber}>5</div>
+                    <div style={styles.cardNumber}>6</div>
                     <div style={styles.cardTitle}>
                       <HelpTooltip concept="control variables">
                         Select Control Variables

--- a/frontend/src/components/VariableSelectionPage.tsx
+++ b/frontend/src/components/VariableSelectionPage.tsx
@@ -59,7 +59,7 @@ const VariableSelectionPage: React.FC = () => {
   const [chatInput, setChatInput] = useState('');
   const [chatLoading, setChatLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
-  const [recommendedQuestions, setRecommendedQuestions] = useState<string[]>([
+  const [recommendedQuestions] = useState<string[]>([
     "Which variables should I control given my treatment and outcome variables?",
     "What are common pitfalls when selecting control variables for DiD?",
     "How do I know if I have enough time periods for DiD?"


### PR DESCRIPTION
Added more foldable explanation in the results page that explains counterfactual and effect size. 
Unit variable selection is back and mendatory. 
Added automatic group assignment logic. 
If user specifies group assignment, it will use the specified units as control and treatment group. 
If the section is empty, we automatically assign treatment and control units based on the treatment value. If at least one of the data for a unit has a value equal to the specific treatment value, it will assign it to the treatment group. 

This restructuring of variable selection and group assignment allows more flexible study design that support various data types. 