### PR TITLE
feat: add rate limiting, AI usage limits, and Supabase RLS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -79,6 +79,10 @@ app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
 from models import db  # noqa: E402
 db.init_app(app)
 
+# --- Rate Limiter ---
+from utils.rate_limiter import limiter  # noqa: E402
+limiter.init_app(app)
+
 # Import blueprints after db initialization
 # Models are imported within routes to avoid circular imports
 from routes.analysis import analysis_bp  # noqa: E402
@@ -100,6 +104,21 @@ app.register_blueprint(analysis_bp)
 app.register_blueprint(projects_bp)
 app.register_blueprint(datasets_bp)
 app.register_blueprint(ai_bp)
+
+
+@app.errorhandler(429)
+def handle_rate_limit(error):
+    """Return a structured JSON response when a rate limit is exceeded."""
+    retry_after = getattr(error, 'retry_after', None)
+    response = jsonify({
+        "error": "Too many requests. Please slow down.",
+        "error_type": "rate_limit_exceeded",
+        "retry_after": int(retry_after) if retry_after else None,
+    })
+    response.status_code = 429
+    if retry_after:
+        response.headers["Retry-After"] = str(int(retry_after))
+    return response
 
 
 @app.errorhandler(500)

--- a/backend/migrations/rls_enable.sql
+++ b/backend/migrations/rls_enable.sql
@@ -1,0 +1,117 @@
+-- =============================================================================
+-- Supabase Row-Level Security (RLS) Migration
+-- =============================================================================
+-- Context
+-- -------
+-- This application manages its own authentication (JWT via Flask-JWT-Extended)
+-- and connects to Supabase through the *direct / pooler connection string*
+-- (DATABASE_URL, port 5432 / 6543).  That connection uses the privileged
+-- `postgres` or `service_role` database role, which BYPASSES RLS entirely.
+-- The Flask backend therefore continues to work unchanged after enabling RLS.
+--
+-- What this migration fixes
+-- -------------------------
+-- Supabase's PostgREST layer exposes every table in the `public` schema
+-- via its REST API.  Without RLS, any holder of an `anon` or `authenticated`
+-- Supabase JWT (not the same as our app JWTs) could read or modify rows
+-- directly through the REST API endpoint (https://<project>.supabase.co/rest).
+-- Enabling RLS with a "deny-all" default (no policies added) closes that gap.
+--
+-- How to run
+-- ----------
+-- 1. Open the Supabase dashboard → SQL Editor.
+-- 2. Paste this file and click "Run".
+-- 3. Optionally verify with:
+--      SELECT tablename, rowsecurity
+--      FROM pg_tables
+--      WHERE schemaname = 'public';
+--    All listed tables should show rowsecurity = true.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1.  Enable RLS on every application table
+--     Effect: all rows are *denied* by default for PostgREST roles (anon /
+--     authenticated) unless an explicit GRANT + POLICY allows them.
+--     The backend's direct-connection role is exempt and keeps full access.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.users            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.projects         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.datasets         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.analyses         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_datasets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_usage_logs    ENABLE ROW LEVEL SECURITY;
+
+
+-- ---------------------------------------------------------------------------
+-- 2.  Revoke default public privileges
+--     PostgREST inherits its table access from the `anon` and `authenticated`
+--     roles.  Explicitly revoking prevents accidental access even if RLS
+--     policies are added incorrectly later.
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON public.users            FROM anon, authenticated;
+REVOKE ALL ON public.projects         FROM anon, authenticated;
+REVOKE ALL ON public.datasets         FROM anon, authenticated;
+REVOKE ALL ON public.analyses         FROM anon, authenticated;
+REVOKE ALL ON public.project_datasets FROM anon, authenticated;
+REVOKE ALL ON public.ai_usage_logs    FROM anon, authenticated;
+
+
+-- ---------------------------------------------------------------------------
+-- 3.  (Optional / future) Per-row ownership policies
+--
+--     Uncomment and adapt these blocks ONLY if you later want to expose
+--     data via Supabase Auth + PostgREST (e.g. a mobile client that calls
+--     the Supabase REST endpoint directly).
+--
+--     Prerequisites:
+--       a) Add a UUID column `auth_user_id uuid` to each table that
+--          stores the Supabase auth.uid() of the owner.
+--       b) GRANT SELECT / INSERT / UPDATE / DELETE back to `authenticated`.
+--       c) Create the policies below.
+--
+-- ---------------------------------------------------------------------------
+
+-- -- Allow authenticated users to read their own user row
+-- CREATE POLICY "users: select own row"
+--   ON public.users
+--   FOR SELECT
+--   TO authenticated
+--   USING ( (SELECT auth.uid()) = auth_user_id );
+--
+-- -- Allow authenticated users to update their own user row
+-- CREATE POLICY "users: update own row"
+--   ON public.users
+--   FOR UPDATE
+--   TO authenticated
+--   USING ( (SELECT auth.uid()) = auth_user_id )
+--   WITH CHECK ( (SELECT auth.uid()) = auth_user_id );
+--
+-- -- Allow authenticated users to read their own projects
+-- CREATE POLICY "projects: select own rows"
+--   ON public.projects
+--   FOR SELECT
+--   TO authenticated
+--   USING (
+--     user_id = (
+--       SELECT id FROM public.users
+--       WHERE auth_user_id = (SELECT auth.uid())
+--       LIMIT 1
+--     )
+--   );
+--
+-- -- (Repeat the pattern for datasets, analyses, etc.)
+
+
+-- ---------------------------------------------------------------------------
+-- 4.  Verify
+-- ---------------------------------------------------------------------------
+
+-- Run this after applying to confirm RLS is active on all tables:
+--
+-- SELECT tablename, rowsecurity
+-- FROM   pg_tables
+-- WHERE  schemaname = 'public'
+-- ORDER  BY tablename;

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import check_password_hash
-from datetime import datetime
+from datetime import datetime, date
 
 # Initialize db here to avoid circular imports
 db = SQLAlchemy()
@@ -135,3 +135,39 @@ class Analysis(db.Model):
     config = db.Column(db.JSON, nullable=True)
     results = db.Column(db.JSON, nullable=True)
     ai_summary = db.Column(db.Text, nullable=True)
+
+
+class AIUsageLog(db.Model):
+    """Tracks daily AI API calls per user for usage-limit enforcement."""
+    __tablename__ = 'ai_usage_logs'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, index=True)
+    endpoint = db.Column(db.String(80), nullable=False)
+    usage_date = db.Column(db.Date, nullable=False, default=date.today, index=True)
+    request_count = db.Column(db.Integer, nullable=False, default=1)
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'endpoint', 'usage_date', name='uq_ai_usage_per_day'),
+    )
+
+    @classmethod
+    def get_daily_count(cls, user_id: int, endpoint: str, for_date: date | None = None) -> int:
+        """Return the number of AI calls made by *user_id* for *endpoint* today."""
+        if for_date is None:
+            for_date = date.today()
+        row = cls.query.filter_by(user_id=user_id, endpoint=endpoint, usage_date=for_date).first()
+        return row.request_count if row else 0
+
+    @classmethod
+    def increment(cls, db_session, user_id: int, endpoint: str) -> int:
+        """Atomically increment the daily counter and return the new count."""
+        today = date.today()
+        row = cls.query.filter_by(user_id=user_id, endpoint=endpoint, usage_date=today).first()
+        if row:
+            row.request_count += 1
+        else:
+            row = cls(user_id=user_id, endpoint=endpoint, usage_date=today, request_count=1)
+            db_session.add(row)
+        db_session.commit()
+        return row.request_count

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ contourpy==1.3.3
 cycler==0.12.1
 Flask==3.1.1
 flask-cors==6.0.1
+Flask-Limiter==4.1.1
 gunicorn==25.1.0
 Flask-JWT-Extended==4.6.0
 Flask-SQLAlchemy==3.1.1

--- a/backend/routes/ai.py
+++ b/backend/routes/ai.py
@@ -3,24 +3,59 @@ AI-powered analysis assistance endpoints
 Focused on results interpretation
 """
 
+import os
+from datetime import datetime
+
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from models import db, AIUsageLog
 from services.ai_service import get_ai_service
 from services.ai_assistant import get_ai_assistant
-from datetime import datetime, timedelta
-from collections import defaultdict
+from utils.rate_limiter import limiter
 
 ai_bp = Blueprint('ai', __name__, url_prefix='/api/ai')
 
-# Simple in-memory rate limiter for chat
-# Format: {user_id: [list of timestamps]}
-_chat_rate_limiter = defaultdict(list)
-CHAT_RATE_LIMIT = 20  # Max requests per window
-CHAT_RATE_WINDOW = 60  # Time window in seconds
+# ---------------------------------------------------------------------------
+# AI daily usage limits (configurable via environment variables)
+# ---------------------------------------------------------------------------
+# Maximum AI calls per user per day for each logical endpoint group.
+# Override in .env, e.g. AI_DAILY_LIMIT_CHAT=100
+AI_DAILY_LIMIT_CHAT = int(os.environ.get("AI_DAILY_LIMIT_CHAT", 50))
+AI_DAILY_LIMIT_INTERPRET = int(os.environ.get("AI_DAILY_LIMIT_INTERPRET", 20))
+AI_DAILY_LIMIT_RECOMMEND = int(os.environ.get("AI_DAILY_LIMIT_RECOMMEND", 30))
+AI_DAILY_LIMIT_GENERAL = int(os.environ.get("AI_DAILY_LIMIT_GENERAL", 30))
+
+
+def _check_and_increment_daily_limit(user_id: int, endpoint: str, daily_limit: int):
+    """
+    Check whether *user_id* has exceeded *daily_limit* calls for *endpoint*
+    today.  If not, increment the counter atomically.
+
+    Returns (allowed: bool, current_count: int, daily_limit: int).
+    """
+    current = AIUsageLog.get_daily_count(user_id, endpoint)
+    if current >= daily_limit:
+        return False, current, daily_limit
+    new_count = AIUsageLog.increment(db.session, user_id, endpoint)
+    return True, new_count, daily_limit
+
+
+def _daily_limit_error(endpoint: str, current: int, limit: int):
+    return jsonify({
+        "error": (
+            f"Daily AI usage limit reached for '{endpoint}' "
+            f"({current}/{limit}). Resets at midnight UTC."
+        ),
+        "error_type": "daily_limit_exceeded",
+        "current_usage": current,
+        "daily_limit": limit,
+    }), 429
 
 
 @ai_bp.route('/interpret-results', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def interpret_results():
     """
     AI interpretation of analysis results.
@@ -48,6 +83,15 @@ def interpret_results():
     """
     try:
         print("=== AI INTERPRET RESULTS ENDPOINT CALLED ===")
+
+        # Daily usage limit check
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "interpret_results", AI_DAILY_LIMIT_INTERPRET
+        )
+        if not allowed:
+            return _daily_limit_error("interpret-results", count, limit)
+
         data = request.get_json()
         
         if not data:
@@ -139,6 +183,7 @@ def interpret_results():
 
 @ai_bp.route('/recommend-method', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def recommend_method():
     """
     AI Interpretation for causal inference method based on study characteristics.
@@ -154,6 +199,15 @@ def recommend_method():
     """
     try:
         print("=== AI RECOMMEND METHOD ENDPOINT CALLED ===")
+
+        # Daily usage limit check
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "recommend_method", AI_DAILY_LIMIT_RECOMMEND
+        )
+        if not allowed:
+            return _daily_limit_error("recommend-method", count, limit)
+
         data = request.get_json()
         
         if not data:
@@ -228,9 +282,17 @@ def recommend_method():
 
 @ai_bp.route('/suggest-variables', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def suggest_variables():
     """AI-powered variable role suggestions."""
     try:
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "general_ai", AI_DAILY_LIMIT_GENERAL
+        )
+        if not allowed:
+            return _daily_limit_error("suggest-variables", count, limit)
+
         data = request.get_json()
         schema_info = data.get('schema_info')
         causal_question = data.get('causal_question')
@@ -252,9 +314,17 @@ def suggest_variables():
 
 @ai_bp.route('/validate-setup', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def validate_setup():
     """Validate analysis setup before running."""
     try:
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "general_ai", AI_DAILY_LIMIT_GENERAL
+        )
+        if not allowed:
+            return _daily_limit_error("validate-setup", count, limit)
+
         data = request.get_json()
         parameters = data.get('parameters')
         data_summary = data.get('data_summary')
@@ -272,9 +342,17 @@ def validate_setup():
 
 @ai_bp.route('/explain', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def explain_concept():
     """Get AI explanation of a concept."""
     try:
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "general_ai", AI_DAILY_LIMIT_GENERAL
+        )
+        if not allowed:
+            return _daily_limit_error("explain", count, limit)
+
         data = request.get_json()
         concept = data.get('concept')
         user_level = data.get('level', 'beginner')
@@ -292,9 +370,17 @@ def explain_concept():
 
 @ai_bp.route('/next-steps', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def get_next_steps():
     """Get recommended next steps after analysis."""
     try:
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "general_ai", AI_DAILY_LIMIT_GENERAL
+        )
+        if not allowed:
+            return _daily_limit_error("next-steps", count, limit)
+
         data = request.get_json()
         analysis_results = data.get('analysis_results')
         interpretation = data.get('interpretation', {})
@@ -312,6 +398,7 @@ def get_next_steps():
 
 @ai_bp.route('/data-quality-check', methods=['POST'])
 @jwt_required()
+@limiter.limit("30 per minute; 100 per hour")
 def data_quality_check():
     """
     AI-powered data quality assessment for causal analysis.
@@ -333,6 +420,15 @@ def data_quality_check():
     """
     try:
         print("=== AI DATA QUALITY CHECK ENDPOINT CALLED ===")
+
+        # Daily usage limit check
+        user_id = int(get_jwt_identity())
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "general_ai", AI_DAILY_LIMIT_GENERAL
+        )
+        if not allowed:
+            return _daily_limit_error("data-quality-check", count, limit)
+
         data = request.get_json()
         
         if not data:
@@ -364,10 +460,11 @@ def data_quality_check():
 
 @ai_bp.route('/chat', methods=['POST'])
 @jwt_required()
+@limiter.limit("20 per minute; 200 per hour")
 def chat():
     """
     Chat with AI about the study, dataset, or causal inference concepts.
-    
+
     Expected request body:
     {
         "message": "What is the parallel trends assumption?",
@@ -380,11 +477,15 @@ def chat():
             "results": {...}
         }
     }
-    
-    Rate limit: 20 requests per minute per user
+
+    Rate limit: 20 requests per minute (via flask-limiter) +
+                AI_DAILY_LIMIT_CHAT requests per day (via db usage log).
     """
     try:
-        user_id = get_jwt_identity()
+        user_id_str = get_jwt_identity()
+        user_id = int(user_id_str)
+        now = datetime.now()
+
         data = request.get_json()
         
         if not data:
@@ -400,26 +501,14 @@ def chat():
             return jsonify({
                 "error": f"Message too long. Maximum {MAX_MESSAGE_LENGTH} characters allowed."
             }), 400
-        
-        # Rate limiting check
-        now = datetime.now()
-        user_requests = _chat_rate_limiter[user_id]
-        
-        # Remove requests outside the time window
-        user_requests[:] = [req_time for req_time in user_requests 
-                           if (now - req_time).total_seconds() < CHAT_RATE_WINDOW]
-        
-        # Check if user has exceeded rate limit
-        if len(user_requests) >= CHAT_RATE_LIMIT:
-            return jsonify({
-                "error": f"Rate limit exceeded. Maximum {CHAT_RATE_LIMIT} requests per {CHAT_RATE_WINDOW} seconds.",
-                "error_type": "rate_limit_exceeded",
-                "retry_after": CHAT_RATE_WINDOW
-            }), 429
-        
-        # Add current request to rate limiter
-        user_requests.append(now)
-        
+
+        # Daily usage limit check
+        allowed, count, limit = _check_and_increment_daily_limit(
+            user_id, "chat", AI_DAILY_LIMIT_CHAT
+        )
+        if not allowed:
+            return _daily_limit_error("chat", count, limit)
+
         # Get conversation history, context, and dataset info
         conversation_history = data.get('conversation_history', [])
         analysis_context = data.get('analysis_context', {})
@@ -483,3 +572,52 @@ def chat():
         print(f"ERROR: Chat endpoint error: {str(e)}")
         traceback.print_exc()
         return jsonify({"error": f"Chat endpoint error: {str(e)}"}), 500
+
+
+@ai_bp.route('/usage', methods=['GET'])
+@jwt_required()
+def get_usage():
+    """
+    Return the current user's AI usage for today across all endpoint groups.
+
+    Response example:
+    {
+        "date": "2026-02-26",
+        "usage": {
+            "chat":             {"used": 5,  "limit": 50},
+            "interpret_results":{"used": 2,  "limit": 20},
+            "recommend_method": {"used": 0,  "limit": 30},
+            "general_ai":       {"used": 3,  "limit": 30}
+        }
+    }
+    """
+    try:
+        from datetime import date
+        user_id = int(get_jwt_identity())
+        today = date.today()
+
+        usage = {
+            "chat": {
+                "used": AIUsageLog.get_daily_count(user_id, "chat", today),
+                "limit": AI_DAILY_LIMIT_CHAT,
+            },
+            "interpret_results": {
+                "used": AIUsageLog.get_daily_count(user_id, "interpret_results", today),
+                "limit": AI_DAILY_LIMIT_INTERPRET,
+            },
+            "recommend_method": {
+                "used": AIUsageLog.get_daily_count(user_id, "recommend_method", today),
+                "limit": AI_DAILY_LIMIT_RECOMMEND,
+            },
+            "general_ai": {
+                "used": AIUsageLog.get_daily_count(user_id, "general_ai", today),
+                "limit": AI_DAILY_LIMIT_GENERAL,
+            },
+        }
+
+        return jsonify({"date": today.isoformat(), "usage": usage}), 200
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        return jsonify({"error": f"Failed to fetch usage: {str(e)}"}), 500

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -21,6 +21,8 @@ from flask_jwt_extended import (
 import re
 import logging
 
+from utils.rate_limiter import limiter
+
 # Configure logger for this module
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,7 @@ def validate_password(password):
 
 
 @auth_bp.route('/register', methods=['POST'])
+@limiter.limit("5 per minute; 20 per hour")
 def register():
     """
     Register a new user
@@ -141,6 +144,7 @@ def register():
 
 
 @auth_bp.route('/login', methods=['POST'])
+@limiter.limit("10 per minute; 50 per hour")
 def login():
     """
     Login user
@@ -199,6 +203,7 @@ def login():
 
 
 @auth_bp.route('/refresh', methods=['POST'])
+@limiter.limit("30 per minute")
 @jwt_required(refresh=True)
 def refresh():
     """

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -1,0 +1,68 @@
+"""
+Rate limiting configuration using Flask-Limiter.
+
+Storage:
+  - Uses in-memory storage by default (fine for single-process).
+  - Set REDIS_URL env var to switch to Redis for multi-process / production
+    deployments (e.g. REDIS_URL=redis://localhost:6379).
+
+Key functions:
+  - Unauthenticated routes  → keyed by remote IP address.
+  - Authenticated routes    → keyed by JWT user identity (user ID).
+"""
+
+import logging
+import os
+
+from flask import request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+logger = logging.getLogger(__name__)
+
+
+def _get_jwt_identity_or_ip() -> str:
+    """
+    Key function for authenticated endpoints.
+
+    Returns the JWT user identity (user ID string) when a valid JWT is
+    present in the Authorization header, otherwise falls back to the
+    remote IP address.  This prevents one user from consuming another
+    user's rate-limit quota.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        try:
+            # Decode without verification just to extract the subject
+            # (real verification is done by @jwt_required on the route).
+            import jwt as _jwt  # PyJWT
+
+            payload = _jwt.decode(token, options={"verify_signature": False})
+            sub = payload.get("sub")
+            if sub:
+                return f"user:{sub}"
+        except Exception:
+            pass
+    return get_remote_address()
+
+
+# Choose storage backend
+_redis_url = os.environ.get("REDIS_URL")
+if _redis_url:
+    from flask_limiter.storage import RedisStorage  # noqa: F401 (unused at import time)
+    _storage_uri = _redis_url
+    logger.info("Rate limiter: using Redis storage (%s)", _redis_url)  # noqa: E501
+else:
+    _storage_uri = "memory://"
+    logger.info("Rate limiter: using in-memory storage (single-process only)")
+
+# Global limiter instance — call limiter.init_app(app) in app.py
+limiter = Limiter(
+    key_func=_get_jwt_identity_or_ip,
+    storage_uri=_storage_uri,
+    default_limits=["200 per minute", "1000 per hour"],
+    default_limits_exempt_when=lambda: False,
+    headers_enabled=True,          # Add X-RateLimit-* headers to responses
+    strategy="fixed-window",
+)


### PR DESCRIPTION
## Changes
Rate Limiting (flask-limiter)
New utils/rate_limiter.py — global Limiter instance keyed by JWT user ID for authenticated routes and IP for unauthenticated routes; swap to Redis by setting REDIS_URL
Auth endpoints: login (10/min, 50/hr), register (5/min, 20/hr), refresh (30/min) to prevent brute-force
All AI endpoints: 20–30/min per user; global 429 handler returns structured JSON with Retry-After header
AI Daily Usage Limits
New AIUsageLog DB model — persists per-user, per-endpoint daily counters; survives restarts and works across processes
Limits configurable via env vars (AI_DAILY_LIMIT_CHAT=50, AI_DAILY_LIMIT_INTERPRET=20, etc.)
Replaced the old in-memory _chat_rate_limiter dict with the DB-backed system
New GET /api/ai/usage endpoint returns a user's current daily usage vs. limits
Supabase RLS (migrations/rls_enable.sql)
Enables RLS on all 6 tables in public schema — denies PostgREST access by default
Revokes anon/authenticated privileges to close the direct REST API surface
Backend direct connection (service role) is unaffected and bypasses RLS as before
Includes commented-out ownership policy templates for future Supabase Auth integration