### PR TITLE
Improve data check AI and UX

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -612,7 +612,7 @@ Q2 — Did treatment start or change at a specific time for some groups but not 
       (e.g. a new law, a policy in some regions, a program rolled out in certain schools)
       Answer: {fmt(q2_time_change)}
 
-Q3 — Is there something that strongly affects who receives treatment but does NOT directly affect the outcome?
+Q3 — Is there a factor that strongly affects who receives treatment but does NOT directly affect the outcome?
       (e.g. lottery assignment, distance to a facility, administrative rules, encouragement letters)
       Answer: {fmt(q3_instrument)}
 
@@ -731,15 +731,35 @@ OUTPUT FORMAT — Return JSON only:
         
         cols_str = "; ".join(col_summary)
         
-        prompt = f"""Assess data quality for causal inference analysis.
+        prompt = f"""You are an expert in causal inference. Assess the following dataset's readiness for causal analysis (DiD, RDD, or IV).
 
-Data: {total_rows} rows, {total_cols} cols ({numeric_cols} numeric, {categorical_cols} categorical), {missing_pct:.1f}% missing overall.
+Data: {total_rows} rows, {total_cols} columns ({numeric_cols} numeric, {categorical_cols} categorical), {missing_pct:.1f}% missing overall.
 Columns: {cols_str}
 
-IMPORTANT: Data types have already been correctly detected and validated. Do NOT flag issues about incorrect data types (e.g., numeric columns labeled as categorical). Focus on other data quality issues like missing values, outliers, data completeness, and suitability for causal analysis methods.
+RULES:
+1. Do NOT flag data type issues — types have already been validated.
+2. Be concrete and actionable. Vague notes like "data may have issues" are not acceptable.
+3. The user will define their causal variables (treatment, outcome, time, group) in the next step — DO NOT flag the absence of a pre-named treatment variable as a problem. That is normal and expected.
+4. For causal_analysis_readiness, apply this EXACT decision logic:
+   - Use "ready" when ALL of the following hold:
+       * Overall missing data < 15%
+       * No individual column has > 20% missing values
+       * At least 50 rows
+       * The dataset has enough columns that the user CAN plausibly define causal variables (even if not yet named)
+     When "ready", the summary MUST confirm the data is usable and briefly say why. Any remaining low/medium observations go into the issues list but do NOT change the readiness to "needs_work".
+   - Use "needs_work" ONLY when there are REAL data quality problems that require fixing before analysis, such as:
+       * Overall missing data ≥ 15%, OR a critical column has > 20% nulls
+       * Fewer than 50 rows
+       * A single time period exists (DiD is impossible)
+       * Key numeric columns are entirely constant (zero variance)
+     The summary MUST name each specific problem and what to do.
+   - Use "not_suitable" only for fundamental issues that cannot reasonably be fixed (e.g., fewer than 10 rows, all columns are IDs, all values are null).
+5. Each issue must include: a specific description, the affected column if applicable, and a concrete recommendation.
+6. Calibrate overall_score honestly: low/no missingness + sufficient rows + good structure = 80–95. Deduct points only for real problems.
+7. strengths must list genuine positives (e.g., "Large sample size (N={total_rows}) provides good statistical power").
 
-Evaluate for causal analysis (DiD, RDD, IV). Return JSON only:
-{{"overall_score":85,"quality_level":"good/fair/poor","summary":"2-3 sentence summary","issues":[{{"severity":"high/medium/low","issue":"description","column":"column_name or null","recommendation":"how to fix"}}],"strengths":["strength1","strength2"],"recommendations":["rec1","rec2"],"causal_analysis_readiness":"ready/needs_work/not_suitable","potential_variables":{{"outcome_candidates":["col1","col2"],"treatment_candidates":["col1"],"time_candidates":["col1"],"group_candidates":["col1"]}}}}"""
+Return ONLY valid JSON, no markdown:
+{{"overall_score":0-100,"quality_level":"good|fair|poor","summary":"Specific 2-3 sentence summary — must be informative, not generic","issues":[{{"severity":"high|medium|low","issue":"Specific description of the problem","column":"column_name or null","recommendation":"Concrete step-by-step fix"}}],"strengths":["Specific strength 1","Specific strength 2"],"recommendations":["Specific actionable recommendation 1","Specific actionable recommendation 2"],"causal_analysis_readiness":"ready|needs_work|not_suitable","potential_variables":{{"outcome_candidates":["col1"],"treatment_candidates":["col1"],"time_candidates":["col1"],"group_candidates":["col1"]}}}}"""
         
         response = self._call_gemini(prompt)
         

--- a/frontend/src/components/charts/RDScatterPlot.tsx
+++ b/frontend/src/components/charts/RDScatterPlot.tsx
@@ -261,7 +261,8 @@ const RDScatterPlot: React.FC<RDScatterPlotProps> = ({
       <div style={styles.headerSection}>
         <h3 style={styles.title}>RD Visualization</h3>
         <p style={styles.subtitle}>
-          Scatter plot showing the discontinuity at the cutoff (bandwidth = {bandwidth.toFixed(3)})
+          Scatter plot within the bandwidth window [{(cutoff - bandwidth).toFixed(3)}, {(cutoff + bandwidth).toFixed(3)}] &nbsp;
+          <span style={{ fontWeight: 600, color: '#e67e22' }}>Bandwidth = {bandwidth.toFixed(3)}</span>
         </p>
       </div>
 
@@ -301,6 +302,32 @@ const RDScatterPlot: React.FC<RDScatterPlotProps> = ({
               wrapperStyle={{ paddingBottom: '10px' }}
             />
 
+            {/* Bandwidth window — left edge */}
+            <ReferenceLine
+              x={cutoff - bandwidth}
+              stroke="#e67e22"
+              strokeWidth={1.5}
+              strokeDasharray="4 4"
+              label={{
+                value: `−BW`,
+                position: 'insideTopRight',
+                fill: '#e67e22',
+                fontSize: 11,
+              }}
+            />
+            {/* Bandwidth window — right edge */}
+            <ReferenceLine
+              x={cutoff + bandwidth}
+              stroke="#e67e22"
+              strokeWidth={1.5}
+              strokeDasharray="4 4"
+              label={{
+                value: `+BW`,
+                position: 'insideTopLeft',
+                fill: '#e67e22',
+                fontSize: 11,
+              }}
+            />
             {/* Cutoff line */}
             <ReferenceLine
               x={cutoff}
@@ -358,11 +385,11 @@ const RDScatterPlot: React.FC<RDScatterPlotProps> = ({
       </div>
 
       <div style={styles.noteBox}>
-        <strong>How to interpret:</strong> The vertical red line marks the cutoff.
-        Points in blue are the <strong>treated units</strong> ({treatmentSide === 'below' ? 'below' : 'above'} the cutoff),
-        and points in gray are the <strong>control units</strong>.
-        The fitted lines show the local polynomial regression on each side.
-        A discontinuous jump at the cutoff indicates a treatment effect.
+        <strong>How to interpret:</strong> The vertical <span style={{ color: '#dc3545', fontWeight: 600 }}>red dashed line</span> marks
+        the cutoff. The <span style={{ color: '#e67e22', fontWeight: 600 }}>orange dashed lines</span> show the bandwidth
+        window (±{bandwidth.toFixed(3)} around the cutoff) — only observations within this window are used for estimation.
+        Points in blue are <strong>treated units</strong> ({treatmentSide === 'below' ? 'below' : 'above'} the cutoff) and
+        points in gray are <strong>control units</strong>. A jump in the fitted lines at the cutoff indicates a treatment effect.
       </div>
     </div>
   );

--- a/frontend/src/components/charts/RDSensitivityPlot.tsx
+++ b/frontend/src/components/charts/RDSensitivityPlot.tsx
@@ -20,6 +20,7 @@ interface RDSensitivityPlotProps {
   outcomeVar: string;
   cutoff: number;
   optimalBandwidth?: number;
+  selectedBandwidth?: number;
   treatmentSide?: 'above' | 'below';
 }
 
@@ -39,6 +40,7 @@ const RDSensitivityPlot: React.FC<RDSensitivityPlotProps> = ({
   outcomeVar,
   cutoff,
   optimalBandwidth,
+  selectedBandwidth,
   treatmentSide = 'above',
 }) => {
   const { accessToken } = useAuth();
@@ -295,6 +297,22 @@ const RDSensitivityPlot: React.FC<RDSensitivityPlotProps> = ({
             {/* Zero reference line */}
             <ReferenceLine y={0} stroke="#666" strokeDasharray="3 3" />
 
+            {/* Selected (used) bandwidth reference line */}
+            {selectedBandwidth && (
+              <ReferenceLine
+                x={selectedBandwidth}
+                stroke="#e67e22"
+                strokeWidth={2.5}
+                label={{
+                  value: `Selected: ${selectedBandwidth.toFixed(3)}`,
+                  position: 'insideTopRight',
+                  fill: '#e67e22',
+                  fontSize: 12,
+                  fontWeight: 'bold',
+                }}
+              />
+            )}
+
             {/* Optimal bandwidth reference line */}
             {optimalBandwidth && (
               <ReferenceLine
@@ -303,8 +321,8 @@ const RDSensitivityPlot: React.FC<RDSensitivityPlotProps> = ({
                 strokeWidth={2}
                 strokeDasharray="5 5"
                 label={{
-                  value: 'Optimal',
-                  position: 'top',
+                  value: `Optimal: ${optimalBandwidth.toFixed(3)}`,
+                  position: 'insideTopLeft',
                   fill: '#28a745',
                   fontSize: 12,
                   fontWeight: 'bold',
@@ -317,9 +335,13 @@ const RDSensitivityPlot: React.FC<RDSensitivityPlotProps> = ({
 
       {/* Interpretation Note */}
       <div style={styles.noteBox}>
-        <strong>How to interpret:</strong> A stable treatment effect across bandwidths
-        suggests robust results. Large variations may indicate sensitivity to bandwidth
-        choice or model misspecification.
+        <strong>How to interpret:</strong> Each point shows the estimated treatment effect
+        for a given bandwidth. The <span style={{ color: '#e67e22', fontWeight: 600 }}>orange line</span> marks
+        the bandwidth used in your analysis{selectedBandwidth ? ` (${selectedBandwidth.toFixed(3)})` : ''}.
+        {optimalBandwidth && <> The <span style={{ color: '#28a745', fontWeight: 600 }}>green dashed line</span> is
+        the algorithmically optimal bandwidth ({optimalBandwidth.toFixed(3)}).</>}{' '}
+        A stable treatment effect across bandwidths suggests robust results; large variations may
+        indicate sensitivity to bandwidth choice.
       </div>
     </div>
   );

--- a/frontend/src/components/layout/BottomProgressBar.tsx
+++ b/frontend/src/components/layout/BottomProgressBar.tsx
@@ -35,7 +35,7 @@ const BottomProgressBar: React.FC<BottomProgressBarProps> = ({
     <div style={styles.progressBar}>
       <div style={styles.progressContainer}>
         <button onClick={onPrev} style={styles.prevButton}>
-          &lt;
+          Previous
         </button>
 
         <div style={styles.stepsContainer}>
@@ -45,7 +45,8 @@ const BottomProgressBar: React.FC<BottomProgressBarProps> = ({
             const isClickable = isCompleted;
 
             return (
-              <div key={step.id} style={styles.stepContainer}>
+              <React.Fragment key={step.id}>
+                {/* Circle + label — wrapper is exactly circle-width so connectors touch the circles */}
                 <div
                   style={{
                     ...styles.stepWrapper,
@@ -56,8 +57,9 @@ const BottomProgressBar: React.FC<BottomProgressBarProps> = ({
                   <div
                     style={{
                       ...styles.stepCircle,
-                      ...(isCompleted || isCurrent ? styles.stepCircleActive : styles.stepCircleInactive),
-                      ...(isClickable ? styles.stepCircleClickable : {})
+                      ...(isCompleted || isCurrent
+                        ? styles.stepCircleActive
+                        : styles.stepCircleInactive)
                     }}
                   >
                     {isCompleted ? (
@@ -66,25 +68,31 @@ const BottomProgressBar: React.FC<BottomProgressBarProps> = ({
                       <span style={styles.stepNumber}>{index + 1}</span>
                     )}
                   </div>
+                  {/* Label floats below without widening the wrapper */}
                   <span
                     style={{
                       ...styles.stepLabel,
-                      ...(isCompleted || isCurrent ? styles.stepLabelActive : styles.stepLabelInactive)
+                      ...(isCompleted || isCurrent
+                        ? styles.stepLabelActive
+                        : styles.stepLabelInactive)
                     }}
                   >
                     {step.label}
                   </span>
                 </div>
 
+                {/* Connector — flex sibling, stretches to fill space between circles */}
                 {index < steps.length - 1 && (
                   <div
                     style={{
                       ...styles.connector,
-                      ...(isCompleted ? styles.connectorActive : styles.connectorInactive)
+                      ...(isCompleted
+                        ? styles.connectorActive
+                        : styles.connectorInactive)
                     }}
                   />
                 )}
-              </div>
+              </React.Fragment>
             );
           })}
         </div>
@@ -97,12 +105,14 @@ const BottomProgressBar: React.FC<BottomProgressBarProps> = ({
           }}
           disabled={!canGoNext}
         >
-          &gt;
+          Next
         </button>
       </div>
     </div>
   );
 };
+
+const CIRCLE = 40; // circle width/height in px
 
 const styles: Record<string, React.CSSProperties> = {
   progressBar: {
@@ -112,49 +122,51 @@ const styles: Record<string, React.CSSProperties> = {
     right: 0,
     backgroundColor: 'white',
     borderTop: '1px solid #e0e0e0',
-    padding: '20px 0',
+    /* extra top padding so labels (absolutely positioned above) are visible */
+    padding: '28px 0 16px',
     zIndex: 100,
-    boxShadow: '0 -2px 10px rgba(0, 0, 0, 0.1)'
+    boxShadow: '0 -2px 10px rgba(0, 0, 0, 0.08)'
   },
   progressContainer: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    maxWidth: '800px',
+    maxWidth: '960px',
     margin: '0 auto',
-    padding: '0 20px',
-    gap: '20px'
+    padding: '0 24px',
+    gap: '40px'
   },
   stepsContainer: {
+    flex: 1,
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 30
+    /* top-align so connector margin-top aligns with circle center */
+    alignItems: 'flex-start'
   },
-  stepContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    position: 'relative'
-  },
+  /*
+   * Width is locked to the circle size.
+   * The label is positioned absolutely so it doesn't stretch the flex item.
+   * This guarantees connectors are placed flush against the circle edges.
+   */
   stepWrapper: {
+    width: `${CIRCLE}px`,
+    flexShrink: 0,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    position: 'relative',
-    zIndex: 2
+    position: 'relative'
   },
   stepWrapperClickable: {
     cursor: 'pointer'
   },
   stepCircle: {
-    width: '40px',
-    height: '40px',
+    width: `${CIRCLE}px`,
+    height: `${CIRCLE}px`,
     borderRadius: '50%',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     fontSize: '16px',
     fontWeight: 'bold',
+    flexShrink: 0,
     transition: 'all 0.3s ease'
   },
   stepCircleActive: {
@@ -166,23 +178,23 @@ const styles: Record<string, React.CSSProperties> = {
     backgroundColor: '#e0e0e0',
     color: '#999'
   },
-  stepCircleClickable: {
-    cursor: 'pointer',
-    transition: 'transform 0.2s ease, box-shadow 0.2s ease'
-  },
   stepNumber: {
-    fontSize: '12px',
+    fontSize: '13px',
     fontWeight: 'bold'
   },
   checkmark: {
-    fontSize: '14px',
+    fontSize: '15px',
     fontWeight: 'bold'
   },
+  /* Label is absolutely positioned above the circle — doesn't affect flex width */
   stepLabel: {
-    fontSize: '12px',
+    position: 'absolute',
+    bottom: `${CIRCLE + 6}px`,
+    left: '50%',
+    transform: 'translateX(-50%)',
+    fontSize: '13px',
     fontWeight: 500,
     whiteSpace: 'nowrap',
-    marginTop: '8px',
     textAlign: 'center'
   },
   stepLabelActive: {
@@ -191,15 +203,12 @@ const styles: Record<string, React.CSSProperties> = {
   stepLabelInactive: {
     color: '#999'
   },
+  /* Connector: flex sibling between circles; margin-top centers it on the circle */
   connector: {
-    position: 'absolute',
-    top: '35%',
-    left: 'calc(50% + 20px)',
-    width: '40px',
+    flex: 1,
     height: '2px',
-    transform: 'translateY(-50%)',
-    transition: 'all 0.3s ease',
-    zIndex: 1
+    marginTop: `${CIRCLE / 2 - 1}px`,
+    transition: 'background-color 0.3s ease'
   },
   connectorActive: {
     backgroundColor: '#043873'
@@ -211,38 +220,43 @@ const styles: Record<string, React.CSSProperties> = {
     backgroundColor: '#6c757d',
     color: 'white',
     border: 'none',
-    borderRadius: '50%',
-    width: '45px',
-    height: '45px',
-    fontSize: '18px',
+    borderRadius: '6px',
+    padding: '0 22px',
+    height: '44px',
+    fontSize: '15px',
     fontWeight: 600,
     cursor: 'pointer',
     transition: 'all 0.3s ease',
-    boxShadow: '0 2px 8px rgba(108, 117, 125, 0.3)',
+    boxShadow: '0 2px 8px rgba(108, 117, 125, 0.25)',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    whiteSpace: 'nowrap',
+    flexShrink: 0
   },
   nextButton: {
     backgroundColor: '#043873',
     color: 'white',
     border: 'none',
-    borderRadius: '50%',
-    width: '45px',
-    height: '45px',
-    fontSize: '18px',
+    borderRadius: '6px',
+    padding: '0 22px',
+    height: '44px',
+    fontSize: '15px',
     fontWeight: 600,
     cursor: 'pointer',
     transition: 'all 0.3s ease',
-    boxShadow: '0 2px 8px rgba(4, 56, 115, 0.3)',
+    boxShadow: '0 2px 8px rgba(4, 56, 115, 0.25)',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    whiteSpace: 'nowrap',
+    flexShrink: 0
   },
   nextButtonDisabled: {
     backgroundColor: '#e0e0e0',
     color: '#999',
-    cursor: 'not-allowed'
+    cursor: 'not-allowed',
+    boxShadow: 'none'
   }
 };
 

--- a/frontend/src/pages/DataUploadPage.tsx
+++ b/frontend/src/pages/DataUploadPage.tsx
@@ -642,15 +642,26 @@ const DataUploadPage: React.FC = () => {
                         {/* Issues */}
                         {qualityAssessment.issues.length > 0 && (
                           <div style={styles.qualityBlock}>
-                            <h5 style={styles.qualityBlockTitle}>⚠️ Issues Found</h5>
+                            <h5 style={styles.qualityBlockTitle}>
+                              {qualityAssessment.causal_analysis_readiness === 'ready'
+                                ? '💡 Notes & Considerations'
+                                : '⚠️ Issues Found'}
+                            </h5>
                             {qualityAssessment.issues.map((issue, idx) => (
                               <div key={idx} style={{
                                 ...styles.issueItem,
-                                borderLeftColor: issue.severity === 'high' ? '#ef4444' :
-                                               issue.severity === 'medium' ? '#f59e0b' : '#3b82f6'
+                                borderLeftColor: qualityAssessment.causal_analysis_readiness === 'ready'
+                                  ? '#3b82f6'
+                                  : issue.severity === 'high' ? '#ef4444'
+                                  : issue.severity === 'medium' ? '#f59e0b' : '#3b82f6'
                               }}>
-                                <div style={styles.issueSeverity}>
-                                  {issue.severity.toUpperCase()}
+                                <div style={{
+                                  ...styles.issueSeverity,
+                                  color: qualityAssessment.causal_analysis_readiness === 'ready' ? '#3b82f6'
+                                    : issue.severity === 'high' ? '#ef4444'
+                                    : issue.severity === 'medium' ? '#d97706' : '#3b82f6'
+                                }}>
+                                  {qualityAssessment.causal_analysis_readiness === 'ready' ? 'NOTE' : issue.severity.toUpperCase()}
                                   {issue.column && <span style={styles.issueColumn}>• {issue.column}</span>}
                                 </div>
                                 <div style={styles.issueText}>{issue.issue}</div>
@@ -749,7 +760,7 @@ const DataUploadPage: React.FC = () => {
 const styles: Record<string, React.CSSProperties> = {
   contentContainer: {
     paddingTop: '70px',
-    paddingBottom: '100px',
+    paddingBottom: '120px',
     minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f8fafc'
   },

--- a/frontend/src/pages/IVResults.tsx
+++ b/frontend/src/pages/IVResults.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Navbar, BottomProgressBar } from '../components/layout';
+import { formatPValue } from '../utils/format';
 import { useProgressStep } from '../hooks/useProgressStep';
 import { aiService, ResultsInterpretation } from '../services/aiService';
 import { useAuth } from '../contexts/AuthContext';
@@ -95,6 +96,8 @@ const IVResults: React.FC = () => {
   >(null);
   const [showCode, setShowCode] = useState(false);
   const [codeLanguage, setCodeLanguage] = useState<'python' | 'r'>('python');
+  const [outcomeLabel, setOutcomeLabel] = useState<string>('');
+  const [editingOutcomeLabel, setEditingOutcomeLabel] = useState(false);
 
   const recommendedQuestions = [
     'What is the exclusion restriction assumption?',
@@ -410,6 +413,7 @@ print(p2)`;
 
       if (loadedResults) {
         setResults(loadedResults);
+        setOutcomeLabel(loadedResults.parameters?.outcome || 'outcome');
 
         // Load cached AI interpretation
         const interpretationKey = projectId
@@ -789,10 +793,43 @@ print(p2)`;
                     <span style={styles.estimandBadge}>{res.estimand}</span>
                   )}
                 </div>
-                <div style={styles.effectValue}>
-                  {typeof res.treatment_effect === 'number'
-                    ? res.treatment_effect.toFixed(3)
-                    : '—'}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '14px' }}>
+                  <div style={styles.effectValue}>
+                    {typeof res.treatment_effect === 'number'
+                      ? res.treatment_effect.toFixed(3)
+                      : '—'}
+                  </div>
+                  {editingOutcomeLabel ? (
+                    <input
+                      autoFocus
+                      value={outcomeLabel}
+                      onChange={e => setOutcomeLabel(e.target.value)}
+                      onBlur={() => setEditingOutcomeLabel(false)}
+                      onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setEditingOutcomeLabel(false); }}
+                      style={{
+                        fontSize: '18px', color: '#043873',
+                        border: 'none', borderBottom: '2px solid #043873',
+                        background: 'transparent', outline: 'none',
+                        fontWeight: '500', textAlign: 'center',
+                        padding: '2px 6px', minWidth: '80px', maxWidth: '200px',
+                      }}
+                    />
+                  ) : (
+                    <span
+                      onClick={() => setEditingOutcomeLabel(true)}
+                      title="Click to edit variable name"
+                      style={{
+                        fontSize: '17px', color: '#043873', fontWeight: '500',
+                        cursor: 'pointer', padding: '4px 10px',
+                        border: '1px dashed #b3d0ff', borderRadius: '8px',
+                        backgroundColor: '#f0f7ff',
+                        display: 'inline-flex', alignItems: 'center', gap: '5px',
+                      }}
+                    >
+                      {outcomeLabel}
+                      <span style={{ fontSize: '12px', color: '#6c9bd4', marginLeft: '2px' }}>✏️</span>
+                    </span>
+                  )}
                 </div>
                 <div
                   style={{
@@ -849,7 +886,7 @@ print(p2)`;
                   <div style={styles.statRowItem}>
                     <span style={styles.statRowLabel}>P-Value</span>
                     <span style={styles.statRowValue}>
-                      {res.p_value?.toFixed(4)}
+                      {formatPValue(res.p_value)}
                     </span>
                     <button
                       type="button"
@@ -908,7 +945,7 @@ print(p2)`;
                     {expandedStat === 'pvalue' && (
                       <>
                         <p style={styles.explanationSimple}>
-                          <strong>Simply put:</strong> The p-value of <strong>{res.p_value?.toFixed(4)}</strong> represents
+                          <strong>Simply put:</strong> The p-value of <strong>{formatPValue(res.p_value)}</strong> represents
                           the probability of seeing an effect this large (or larger) purely by chance if there were truly no effect.
                           {res.p_value < 0.05
                             ? ' Since it is below 0.05, the result is considered statistically significant.'
@@ -966,7 +1003,7 @@ print(p2)`;
                         F = {res.first_stage.f_statistic?.toFixed(2)}
                       </span>
                       <span style={styles.fStatNote}>
-                        {' '}(p = {res.first_stage.f_p_value?.toFixed(4)})
+                        {' '}(p = {formatPValue(res.first_stage.f_p_value)})
                       </span>
                     </div>
                     <StrengthBadge strength={res.instrument_strength.strength} />
@@ -1072,7 +1109,7 @@ print(p2)`;
                                     coef.p_value < 0.05 ? '600' : 'normal',
                                 }}
                               >
-                                {coef.p_value?.toFixed(4)}
+                                {formatPValue(coef.p_value)}
                               </span>
                             </div>
                           ))}
@@ -1106,7 +1143,7 @@ print(p2)`;
                               : '#666',
                         }}
                       >
-                        {res.endogeneity_test.p_value?.toFixed(4)}
+                        {formatPValue(res.endogeneity_test.p_value)}
                       </span>
                     </div>
                     <div
@@ -1164,7 +1201,7 @@ print(p2)`;
                           color: overid.p_value < 0.05 ? '#721c24' : '#155724',
                         }}
                       >
-                        {overid.p_value?.toFixed(4)}
+                        {formatPValue(overid.p_value)}
                       </span>
                     </div>
                     <div>
@@ -1332,7 +1369,7 @@ print(p2)`;
                                   color: row.p_value < 0.05 ? '#155724' : '#666',
                                 }}
                               >
-                                {row.p_value?.toFixed(4)}
+                                {formatPValue(row.p_value)}
                               </span>
                               <span style={{ fontFamily: 'monospace', fontSize: '12px' }}>
                                 [{row.ci_lower?.toFixed(3)}, {row.ci_upper?.toFixed(3)}]

--- a/frontend/src/pages/IVSetup.tsx
+++ b/frontend/src/pages/IVSetup.tsx
@@ -1158,7 +1158,7 @@ export default IVSetup;
 const styles = {
   contentContainer: {
     paddingTop: '70px',
-    paddingBottom: '80px',
+    paddingBottom: '120px',
     minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f5f5f5',
   },

--- a/frontend/src/pages/MethodSelectionPage.tsx
+++ b/frontend/src/pages/MethodSelectionPage.tsx
@@ -291,100 +291,46 @@ const MethodSelectionPage: React.FC = () => {
                             <div style={styles.aiOnlineDot} title="Online" />
                         </div>
 
-                        {/* Chat messages */}
-                        <div className="ai-chat-messages" style={styles.chatMessages}>
-                            {chatMessages.map((msg, idx) => (
-                                <div key={idx} style={msg.role === 'user' ? styles.userRow : styles.aiRow}>
-                                    {msg.role === 'assistant' && <div style={styles.msgAvatar}>🤖</div>}
-                                    <div style={msg.role === 'user' ? styles.userBubble : styles.aiBubble}>
-                                        {msg.content.split('\n').map((line, i, arr) => (
-                                            <span key={i}>{line}{i < arr.length - 1 && <br />}</span>
-                                        ))}
-                                        {msg.recommendation && (
-                                            <RecommendationCard
-                                                rec={msg.recommendation}
-                                                onSelect={handleMethodSelect}
-                                                styles={styles}
-                                            />
-                                        )}
-                                    </div>
-                                </div>
-                            ))}
-
-                            {(chatLoading || recLoading) && (
-                                <div style={styles.aiRow}>
-                                    <div style={styles.msgAvatar}>🤖</div>
-                                    <div style={styles.aiBubble}>
-                                        <div className="typing-indicator">
-                                            <span className="typing-dot" />
-                                            <span className="typing-dot" />
-                                            <span className="typing-dot" />
-                                        </div>
-                                    </div>
-                                </div>
-                            )}
-                            <div ref={chatEndRef} />
+                        {/* Mode tabs — fixed at top */}
+                        <div style={styles.modeTabs}>
+                            <button
+                                style={{ ...styles.modeTab, ...(inputMode === 'recommend' ? styles.modeTabActive : {}) }}
+                                onClick={() => { setInputMode('recommend'); setRecError(null); }}
+                            >
+                                🎯 Recommend
+                            </button>
+                            <button
+                                style={{ ...styles.modeTab, ...(inputMode === 'chat' ? styles.modeTabActive : {}) }}
+                                onClick={() => setInputMode('chat')}
+                            >
+                                💬 Chat
+                            </button>
                         </div>
 
-                        {/* Input area */}
-                        <div style={styles.inputArea}>
-                            {/* Mode tabs */}
-                            <div style={styles.modeTabs}>
-                                <button
-                                    style={{ ...styles.modeTab, ...(inputMode === 'recommend' ? styles.modeTabActive : {}) }}
-                                    onClick={() => { setInputMode('recommend'); setRecError(null); }}
-                                >
-                                    🎯 Recommend
-                                </button>
-                                <button
-                                    style={{ ...styles.modeTab, ...(inputMode === 'chat' ? styles.modeTabActive : {}) }}
-                                    onClick={() => setInputMode('chat')}
-                                >
-                                    💬 Chat
-                                </button>
-                            </div>
-
-                            {/* Chat mode */}
-                            {inputMode === 'chat' && (
-                                <div style={styles.chatInputRow}>
-                                    <textarea
-                                        style={styles.chatTextarea}
-                                        placeholder="Ask anything about causal inference… (Shift+Enter for new line)"
-                                        value={chatInput}
-                                        onChange={e => setChatInput(e.target.value)}
-                                        onKeyDown={handleChatKeyDown}
-                                        rows={3}
-                                    />
-                                    <button
-                                        style={{
-                                            ...styles.sendBtn,
-                                            ...(!chatInput.trim() || chatLoading ? styles.sendBtnDisabled : {})
-                                        }}
-                                        onClick={handleSendChat}
-                                        disabled={!chatInput.trim() || chatLoading}
-                                        title="Send (Enter)"
-                                    >
-                                        <svg viewBox="0 0 24 24" width="20" height="20" fill="white">
-                                            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-                                        </svg>
-                                    </button>
+                        {/* ── Recommend pane ── */}
+                        {inputMode === 'recommend' && (
+                            <div style={styles.recommendPane}>
+                                {/* Helper banner */}
+                                <div style={styles.helpBanner}>
+                                    <p style={styles.helpBannerText}>
+                                        Not sure which method to choose?<br />I can help you!
+                                    </p>
+                                    <p style={styles.helpBannerSub}>
+                                        Answer a few quick questions and I'll recommend the best causal inference method for your study.
+                                    </p>
                                 </div>
-                            )}
 
-                            {/* Recommend mode */}
-                            {inputMode === 'recommend' && (
                                 <div style={styles.recForm}>
                                     {recError && <div style={styles.recError}>⚠️ {recError}</div>}
 
-                                    {/* Variables */}
                                     <div style={styles.recInputGrid}>
                                         <div style={styles.recField}>
                                             <label style={styles.recLabel}>Treatment variable <span style={styles.req}>*</span></label>
-                                            <input style={styles.recInput} placeholder="e.g., scholarship, policy" value={treatmentVariable} onChange={e => setTreatmentVariable(e.target.value)} />
+                                            <input style={styles.recInput} placeholder="e.g., scholarship" value={treatmentVariable} onChange={e => setTreatmentVariable(e.target.value)} />
                                         </div>
                                         <div style={styles.recField}>
                                             <label style={styles.recLabel}>Outcome variable <span style={styles.req}>*</span></label>
-                                            <input style={styles.recInput} placeholder="e.g., graduation rate, sales" value={outcomeVariable} onChange={e => setOutcomeVariable(e.target.value)} />
+                                            <input style={styles.recInput} placeholder="e.g., graduation rate" value={outcomeVariable} onChange={e => setOutcomeVariable(e.target.value)} />
                                         </div>
                                     </div>
                                     <textarea
@@ -395,7 +341,6 @@ const MethodSelectionPage: React.FC = () => {
                                         rows={2}
                                     />
 
-                                    {/* Three guided questions */}
                                     <QuestionRow
                                         number={1}
                                         question="Is treatment determined by crossing a clear cutoff or rule?"
@@ -429,11 +374,76 @@ const MethodSelectionPage: React.FC = () => {
                                         onClick={handleGetRecommendation}
                                         disabled={recLoading || !treatmentVariable.trim() || !outcomeVariable.trim()}
                                     >
-                                        {recLoading ? 'Analyzing…' : '🎯 Get Recommendation'}
+                                        {recLoading ? 'Analyzing…' : 'Get Recommendation'}
                                     </button>
                                 </div>
-                            )}
-                        </div>
+                            </div>
+                        )}
+
+                        {/* ── Chat pane ── */}
+                        {inputMode === 'chat' && (
+                            <>
+                                <div className="ai-chat-messages" style={styles.chatMessages}>
+                                    {chatMessages.map((msg, idx) => (
+                                        <div key={idx} style={msg.role === 'user' ? styles.userRow : styles.aiRow}>
+                                            {msg.role === 'assistant' && <div style={styles.msgAvatar}>🤖</div>}
+                                            <div style={msg.role === 'user' ? styles.userBubble : styles.aiBubble}>
+                                                {msg.content.split('\n').map((line, i, arr) => (
+                                                    <span key={i}>{line}{i < arr.length - 1 && <br />}</span>
+                                                ))}
+                                                {msg.recommendation && (
+                                                    <RecommendationCard
+                                                        rec={msg.recommendation}
+                                                        onSelect={handleMethodSelect}
+                                                        styles={styles}
+                                                    />
+                                                )}
+                                            </div>
+                                        </div>
+                                    ))}
+
+                                    {chatLoading && (
+                                        <div style={styles.aiRow}>
+                                            <div style={styles.msgAvatar}>🤖</div>
+                                            <div style={styles.aiBubble}>
+                                                <div className="typing-indicator">
+                                                    <span className="typing-dot" />
+                                                    <span className="typing-dot" />
+                                                    <span className="typing-dot" />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
+                                    <div ref={chatEndRef} />
+                                </div>
+
+                                <div style={styles.inputArea}>
+                                    <div style={styles.chatInputRow}>
+                                        <textarea
+                                            style={styles.chatTextarea}
+                                            placeholder="Ask anything about causal inference… (Shift+Enter for new line)"
+                                            value={chatInput}
+                                            onChange={e => setChatInput(e.target.value)}
+                                            onKeyDown={handleChatKeyDown}
+                                            rows={3}
+                                        />
+                                        <button
+                                            style={{
+                                                ...styles.sendBtn,
+                                                ...(!chatInput.trim() || chatLoading ? styles.sendBtnDisabled : {})
+                                            }}
+                                            onClick={handleSendChat}
+                                            disabled={!chatInput.trim() || chatLoading}
+                                            title="Send (Enter)"
+                                        >
+                                            <svg viewBox="0 0 24 24" width="20" height="20" fill="white">
+                                                <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </>
+                        )}
                     </div>
                 </div>
             </div>
@@ -471,7 +481,7 @@ const RecommendationCard: React.FC<{
         {rec.why_not_others && (
             <div style={styles.recCardSection}>
                 <p style={styles.recCardLabel}>Why Not the Others?</p>
-                <p style={{ ...styles.recCardExplanation, color: '#64748b', margin: 0 }}>{rec.why_not_others}</p>
+                <p style={{ ...styles.recCardExplanation, color: '#374151', margin: 0 }}>{rec.why_not_others}</p>
             </div>
         )}
         {rec.alternatives.length > 0 && (
@@ -508,9 +518,11 @@ const QuestionRow: React.FC<{
     return (
         <div style={styles.questionRow}>
             <div style={styles.questionHeader}>
-                <div style={styles.questionBadge}>{number}</div>
+                <div style={styles.questionBadge}>
+                    {number}
+                </div>
                 <div>
-                    <p style={styles.questionText}>{question}</p>
+                    <p style={styles.questionText}>{question}<span style={{ color: '#ef4444', fontSize: '13px', marginLeft: '3px', lineHeight: 1 }}>*</span></p>
                     <p style={styles.questionExample}>{example}</p>
                 </div>
             </div>
@@ -894,7 +906,7 @@ export default MethodSelectionPage;
 const styles: Record<string, React.CSSProperties> = {
     contentContainer: {
         paddingTop: '80px',
-        paddingBottom: '100px',
+        paddingBottom: '120px',
         minHeight: 'calc(100vh - 80px)',
         backgroundColor: '#f5f5f5'
     },
@@ -919,8 +931,8 @@ const styles: Record<string, React.CSSProperties> = {
         gap: '28px'
     },
     header: { textAlign: 'center' },
-    pageTitle: { fontSize: '26px', fontWeight: 'bold', color: '#043873', margin: '0 0 8px 0' },
-    subtitle: { fontSize: '15px', color: '#666', margin: 0 },
+    pageTitle: { fontSize: '34px', fontWeight: 'bold', color: '#043873', margin: '0 0 10px 0' },
+    subtitle: { fontSize: '17px', color: '#374151', margin: 0 },
 
     cardsContainer: {
         display: 'grid',
@@ -931,7 +943,7 @@ const styles: Record<string, React.CSSProperties> = {
     methodCard: {
         backgroundColor: 'white',
         borderRadius: '14px',
-        padding: '20px 16px',
+        padding: '22px 18px',
         boxShadow: '0 2px 10px rgba(0,0,0,0.06)',
         cursor: 'pointer',
         border: '2px solid transparent',
@@ -940,7 +952,7 @@ const styles: Record<string, React.CSSProperties> = {
         flexDirection: 'column',
         alignItems: 'center',
         textAlign: 'center',
-        minHeight: '190px'
+        minHeight: '210px'
     },
     methodCardDisabled: { opacity: 0.65 },
     selectedCard: {
@@ -955,26 +967,26 @@ const styles: Record<string, React.CSSProperties> = {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: '10px'
+        gap: '12px'
     },
-    icon: { fontSize: '32px' },
-    cardTitle: { fontSize: '14px', fontWeight: '600', color: '#043873', margin: 0, lineHeight: '1.3' },
-    cardDescription: { fontSize: '12px', color: '#666', lineHeight: '1.4', margin: 0 },
+    icon: { fontSize: '40px' },
+    cardTitle: { fontSize: '18px', fontWeight: '700', color: '#043873', margin: 0, lineHeight: '1.3' },
+    cardDescription: { fontSize: '14px', color: '#374151', lineHeight: '1.5', margin: 0 },
     cardRadio: { marginTop: '14px' },
     radioOuter: {
-        width: '20px', height: '20px', borderRadius: '50%',
+        width: '22px', height: '22px', borderRadius: '50%',
         border: '2px solid #cbd5e1',
         display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s'
     },
     radioOuterSelected: { borderColor: '#043873' },
-    radioInner: { width: '11px', height: '11px', borderRadius: '50%', backgroundColor: '#043873' },
+    radioInner: { width: '12px', height: '12px', borderRadius: '50%', backgroundColor: '#043873' },
     statusBadge: {
         backgroundColor: '#d4edda', color: '#155724',
-        padding: '3px 10px', borderRadius: '10px', fontSize: '10px', fontWeight: '600', marginBottom: '10px'
+        padding: '4px 12px', borderRadius: '10px', fontSize: '12px', fontWeight: '600', marginBottom: '10px'
     },
     comingSoonBadge: {
-        backgroundColor: '#f1f5f9', color: '#64748b',
-        padding: '3px 10px', borderRadius: '10px', fontSize: '10px', fontWeight: '600', marginBottom: '10px'
+        backgroundColor: '#f1f5f9', color: '#374151',
+        padding: '4px 12px', borderRadius: '10px', fontSize: '12px', fontWeight: '600', marginBottom: '10px'
     },
 
     // ── AI Panel ──────────────────────────────────────────────────────────────
@@ -1006,8 +1018,8 @@ const styles: Record<string, React.CSSProperties> = {
         backgroundColor: 'rgba(255,255,255,0.18)', borderRadius: '50%',
         display: 'flex', alignItems: 'center', justifyContent: 'center'
     },
-    aiPanelTitle: { color: 'white', fontWeight: '700', fontSize: '14px' },
-    aiPanelSubtitle: { color: 'rgba(255,255,255,0.65)', fontSize: '11px', marginTop: '1px' },
+    aiPanelTitle: { color: 'white', fontWeight: '700', fontSize: '16px' },
+    aiPanelSubtitle: { color: 'rgba(255,255,255,0.65)', fontSize: '13px', marginTop: '1px' },
     aiOnlineDot: {
         width: '9px', height: '9px', borderRadius: '50%',
         backgroundColor: '#4ade80', boxShadow: '0 0 0 2px rgba(74,222,128,0.3)'
@@ -1029,40 +1041,72 @@ const styles: Record<string, React.CSSProperties> = {
         backgroundColor: '#043873', color: 'white',
         borderRadius: '16px 16px 4px 16px',
         padding: '10px 14px', maxWidth: '84%',
-        fontSize: '13px', lineHeight: '1.55'
+        fontSize: '14px', lineHeight: '1.55'
     },
     aiBubble: {
         backgroundColor: 'white', color: '#1e293b',
         borderRadius: '4px 16px 16px 16px',
         padding: '10px 14px', maxWidth: '92%',
-        fontSize: '13px', lineHeight: '1.55',
+        fontSize: '14px', lineHeight: '1.55',
         boxShadow: '0 1px 4px rgba(0,0,0,0.07)',
         border: '1px solid #e8ecf0'
     },
 
-    // ── Input area ────────────────────────────────────────────────────────────
-    inputArea: {
-        borderTop: '1px solid #e8ecf0',
+    // ── Mode tabs (fixed at top of panel) ────────────────────────────────────
+    modeTabs: {
+        display: 'flex',
+        borderBottom: '2px solid #e8ecf0',
         backgroundColor: 'white',
         flexShrink: 0
     },
-    modeTabs: {
-        display: 'flex',
-        borderBottom: '1px solid #f0f0f0',
-        padding: '0 12px'
-    },
     modeTab: {
-        flex: 1, padding: '10px 8px',
+        flex: 1, padding: '13px 8px',
         background: 'none', border: 'none',
-        cursor: 'pointer', fontSize: '12.5px',
-        fontWeight: '500', color: '#94a3b8',
-        borderBottom: '2px solid transparent',
-        marginBottom: '-1px', transition: 'all 0.15s'
+        cursor: 'pointer', fontSize: '15px',
+        fontWeight: '500', color: '#64748b',
+        borderBottom: '3px solid transparent',
+        marginBottom: '-2px', transition: 'all 0.15s'
     },
     modeTabActive: {
         color: '#043873',
         borderBottomColor: '#043873',
         fontWeight: '700'
+    },
+
+    // ── Recommend pane ────────────────────────────────────────────────────────
+    recommendPane: {
+        flex: 1,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0',
+        backgroundColor: '#f8fafc'
+    },
+    helpBanner: {
+        backgroundColor: '#043873',
+        padding: '22px 20px 18px',
+        textAlign: 'center',
+        flexShrink: 0
+    },
+    helpBannerText: {
+        fontSize: '21px',
+        fontWeight: '700',
+        color: 'white',
+        margin: '0 0 8px 0',
+        lineHeight: '1.4'
+    },
+    helpBannerSub: {
+        fontSize: '14px',
+        color: 'rgba(255,255,255,0.75)',
+        margin: 0,
+        lineHeight: '1.5'
+    },
+
+    // ── Input area (chat tab only) ────────────────────────────────────────────
+    inputArea: {
+        borderTop: '1px solid #e8ecf0',
+        backgroundColor: 'white',
+        flexShrink: 0
     },
 
     // Chat tab
@@ -1073,7 +1117,7 @@ const styles: Record<string, React.CSSProperties> = {
     chatTextarea: {
         flex: 1,
         padding: '9px 12px',
-        fontSize: '13px',
+        fontSize: '14px',
         border: '1.5px solid #e2e8f0',
         borderRadius: '10px',
         fontFamily: 'inherit',
@@ -1097,10 +1141,11 @@ const styles: Record<string, React.CSSProperties> = {
 
     // Recommend tab
     recForm: {
-        padding: '12px',
+        padding: '14px',
         display: 'flex',
         flexDirection: 'column',
-        gap: '8px'
+        gap: '10px',
+        backgroundColor: '#f8fafc'
     },
     recError: {
         padding: '7px 10px',
@@ -1116,11 +1161,11 @@ const styles: Record<string, React.CSSProperties> = {
         gap: '8px'
     },
     recField: { display: 'flex', flexDirection: 'column', gap: '3px' },
-    recLabel: { fontSize: '11px', fontWeight: '600', color: '#64748b' },
+    recLabel: { fontSize: '13px', fontWeight: '600', color: '#374151' },
     req: { color: '#e74c3c' },
     recInput: {
-        padding: '7px 9px',
-        fontSize: '12.5px',
+        padding: '8px 10px',
+        fontSize: '14px',
         border: '1.5px solid #e2e8f0',
         borderRadius: '7px',
         fontFamily: 'inherit',
@@ -1129,11 +1174,11 @@ const styles: Record<string, React.CSSProperties> = {
     recChecks: { display: 'flex', flexDirection: 'column', gap: '5px' },
     recCheckLabel: {
         display: 'flex', alignItems: 'center', gap: '6px',
-        fontSize: '12px', color: '#475569', cursor: 'pointer'
+        fontSize: '12px', color: '#374151', cursor: 'pointer'
     },
     recCheckbox: { width: '14px', height: '14px', accentColor: '#043873', cursor: 'pointer' },
     recSubmitBtn: {
-        padding: '9px', fontSize: '13px', fontWeight: '600',
+        padding: '10px', fontSize: '15px', fontWeight: '600',
         color: 'white', backgroundColor: '#043873',
         border: 'none', borderRadius: '8px', cursor: 'pointer'
     },
@@ -1161,21 +1206,21 @@ const styles: Record<string, React.CSSProperties> = {
         flexShrink: 0, marginTop: '1px'
     },
     questionText: {
-        fontSize: '12px', fontWeight: '600', color: '#1e293b',
+        fontSize: '14px', fontWeight: '600', color: '#111827',
         margin: '0 0 2px 0', lineHeight: '1.4'
     },
     questionExample: {
-        fontSize: '11px', color: '#64748b', margin: 0, lineHeight: '1.4'
+        fontSize: '13px', color: '#374151', margin: 0, lineHeight: '1.4'
     },
     questionBtns: {
         display: 'flex', gap: '6px'
     },
     questionBtn: {
-        flex: 1, padding: '5px 4px',
+        flex: 1, padding: '6px 4px',
         border: '1.5px solid #e2e8f0',
         borderRadius: '6px', backgroundColor: 'white',
-        fontSize: '11.5px', fontWeight: '500',
-        color: '#475569', cursor: 'pointer',
+        fontSize: '13px', fontWeight: '500',
+        color: '#374151', cursor: 'pointer',
         transition: 'all 0.15s'
     },
 
@@ -1192,7 +1237,7 @@ const styles: Record<string, React.CSSProperties> = {
         fontSize: '12px', fontWeight: '700', marginBottom: '8px'
     },
     recCardExplanation: {
-        fontSize: '12px', color: '#334155', lineHeight: '1.6', margin: '0 0 8px 0'
+        fontSize: '14px', color: '#1e293b', lineHeight: '1.6', margin: '0 0 8px 0'
     },
     recAssumptionBox: {
         backgroundColor: '#fffbeb',
@@ -1206,15 +1251,15 @@ const styles: Record<string, React.CSSProperties> = {
     },
     recCardSection: { marginBottom: '8px' },
     recCardLabel: {
-        fontSize: '10px', fontWeight: '700', color: '#64748b',
+        fontSize: '12px', fontWeight: '700', color: '#374151',
         textTransform: 'uppercase', letterSpacing: '0.5px', margin: '0 0 4px 0'
     },
     recCardList: {
         margin: '0 0 0 14px', padding: 0,
-        fontSize: '11.5px', color: '#475569', lineHeight: '1.7'
+        fontSize: '12px', color: '#374151', lineHeight: '1.7'
     },
     recAltItem: {
-        fontSize: '11.5px', color: '#475569',
+        fontSize: '12px', color: '#374151',
         padding: '4px 7px', backgroundColor: 'white',
         borderRadius: '5px', marginTop: '3px',
         border: '1px solid #e2e8f0', lineHeight: '1.5'
@@ -1237,18 +1282,18 @@ const styles: Record<string, React.CSSProperties> = {
         textAlign: 'center', marginBottom: '22px',
         paddingBottom: '18px', borderBottom: '2px solid #f0f4f8'
     },
-    explanationTitle: { fontSize: '24px', fontWeight: 'bold', color: '#043873', margin: '0 0 8px 0' },
-    explanationSubtitle: { fontSize: '14px', color: '#666', margin: 0 },
+    explanationTitle: { fontSize: '32px', fontWeight: 'bold', color: '#043873', margin: '0 0 8px 0' },
+    explanationSubtitle: { fontSize: '17px', color: '#374151', margin: 0 },
     whenToUseSection: {
         backgroundColor: '#f0f7ff', borderRadius: '10px',
-        padding: '18px 22px', marginBottom: '26px', border: '1px solid #d4e5f7'
+        padding: '20px 24px', marginBottom: '28px', border: '1px solid #d4e5f7'
     },
-    whenToUseTitle: { fontSize: '15px', fontWeight: '600', color: '#043873', margin: '0 0 10px 0' },
-    whenToUseText: { fontSize: '13.5px', color: '#334155', lineHeight: '1.65', margin: 0 },
+    whenToUseTitle: { fontSize: '22px', fontWeight: '700', color: '#043873', margin: '0 0 12px 0' },
+    whenToUseText: { fontSize: '16px', color: '#1e293b', lineHeight: '1.7', margin: 0 },
     explanationContent: { display: 'flex', flexDirection: 'column', gap: '30px' },
     chartSection: { textAlign: 'center' },
     sectionTitle: {
-        fontSize: '16px', fontWeight: '600', color: '#043873', marginBottom: '16px',
+        fontSize: '22px', fontWeight: '700', color: '#043873', marginBottom: '16px',
         display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '7px'
     },
     chartContainer: {
@@ -1257,7 +1302,7 @@ const styles: Record<string, React.CSSProperties> = {
     },
     didChart: { width: '100%', maxWidth: '480px', height: 'auto' },
     chartCaption: {
-        fontSize: '13px', color: '#555', lineHeight: '1.65',
+        fontSize: '15px', color: '#374151', lineHeight: '1.65',
         maxWidth: '580px', margin: '0 auto', textAlign: 'center'
     },
     conceptsSection: {},
@@ -1266,18 +1311,19 @@ const styles: Record<string, React.CSSProperties> = {
         backgroundColor: '#f8fafc', borderRadius: '10px',
         padding: '18px', border: '1px solid #e2e8f0'
     },
-    conceptTitle: { fontSize: '14px', fontWeight: '600', color: '#043873', margin: '0 0 6px 0' },
-    conceptText: { fontSize: '12.5px', color: '#555', lineHeight: '1.6', margin: 0 },
+    conceptTitle: { fontSize: '18px', fontWeight: '700', color: '#043873', margin: '0 0 6px 0' },
+    conceptText: { fontSize: '15px', color: '#374151', lineHeight: '1.6', margin: 0 },
     exampleSection: {},
-    exampleBox: { backgroundColor: '#f8f9fa', borderRadius: '10px', padding: '22px', border: '1px solid #e2e8f0' },
+    exampleBox: { backgroundColor: '#f8f9fa', borderRadius: '10px', padding: '22px', border: '1px solid #e2e8f0', color: '#1e293b', fontSize: '15px' },
     exampleScenario: {
         backgroundColor: '#e8f4fc', borderRadius: '7px',
-        padding: '13px 18px', marginBottom: '16px', borderLeft: '4px solid #3498db'
+        padding: '13px 18px', marginBottom: '16px', borderLeft: '4px solid #3498db', color: '#1e293b'
     },
     exampleSteps: { display: 'flex', flexDirection: 'column', gap: '10px' },
     exampleStep: {
         display: 'flex', alignItems: 'flex-start', gap: '12px',
-        backgroundColor: 'white', padding: '12px', borderRadius: '7px', border: '1px solid #eee'
+        backgroundColor: 'white', padding: '12px', borderRadius: '7px', border: '1px solid #eee',
+        color: '#1e293b', fontSize: '15px'
     },
     stepNumber: {
         width: '26px', height: '26px', borderRadius: '50%',
@@ -1299,8 +1345,8 @@ const styles: Record<string, React.CSSProperties> = {
         fontSize: '12px', color: '#aaa'
     },
     comingSoonContent: {
-        textAlign: 'center', padding: '40px 20px', color: '#666',
+        textAlign: 'center', padding: '40px 20px', color: '#374151',
         backgroundColor: '#f8fafc', borderRadius: '10px', border: '2px dashed #e2e8f0'
     },
-    comingSoonText: { fontSize: '18px', fontWeight: '600', color: '#64748b', margin: '0 0 10px 0' }
+    comingSoonText: { fontSize: '18px', fontWeight: '600', color: '#374151', margin: '0 0 10px 0' }
 };

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -45,8 +45,8 @@ const ProjectsPage: React.FC = () => {
   // Pre-selected dataset from DataUploadPage
   const preSelectedDatasetId = (location.state as any)?.selectedDatasetId || null;
 
-  // Load projects from API
-  const loadProjects = async () => {
+  // Load projects from API — returns the mapped list so callers can use it
+  const loadProjects = async (): Promise<Project[]> => {
     try {
       setLoading(true);
       const response = await axios.get('/projects', {
@@ -91,8 +91,10 @@ const ProjectsPage: React.FC = () => {
       );
 
       setProjects(mappedProjects);
+      return mappedProjects;
     } catch (error) {
       console.error('Error loading projects:', error);
+      return [];
     } finally {
       setLoading(false);
     }
@@ -133,22 +135,32 @@ const ProjectsPage: React.FC = () => {
         });
       }
 
-      // Map backend response to frontend format
-      const mappedProject = {
+      // Build a local copy immediately — include a minimal datasets entry so
+      // handleNext (which guards on checkedProject.datasets[0].id) can proceed
+      // right away without waiting for the reload.
+      const mappedProject: Project = {
         id: newProject.id,
-        title: newProject.name,  // Map 'name' to 'title' for frontend
+        title: newProject.name,
         description: newProject.description,
-        created_at: new Date().toISOString(),  // Add timestamp
-        dataset_count: datasetId ? 1 : 0
+        created_at: new Date().toISOString(),
+        dataset_count: datasetId ? 1 : 0,
+        datasets: datasetId ? [{ id: datasetId, name: '', file_name: '', created_at: '' }] : [],
       };
 
       setProjects([...projects, mappedProject]);
       setSelectedProject(mappedProject);
       setCheckedProject(mappedProject);
-      setIsReadyForNext(datasetId ? true : false);
+      setIsReadyForNext(!!datasetId);
 
-      // Reload projects to get accurate data
-      loadProjects();
+      // Reload from the server to get accurate dataset metadata, then
+      // re-sync checkedProject so it has the full data.
+      const freshProjects = await loadProjects();
+      const freshProject = freshProjects.find(p => p.id === newProject.id);
+      if (freshProject) {
+        setSelectedProject(freshProject);
+        setCheckedProject(freshProject);
+        setIsReadyForNext((freshProject.datasets?.length ?? 0) > 0);
+      }
     } catch (error) {
       console.error('Error creating project:', error);
       throw error;
@@ -377,9 +389,9 @@ const styles = {
     backgroundColor: '#f5f5f5'
   },
   contentContainer: {
-    paddingTop: '70px', // Account for fixed navbar height
-    paddingBottom: '80px', // Account for fixed bottom progress bar
-    minHeight: 'calc(100vh - 70px)', // Full height minus navbar
+    paddingTop: '70px',
+    paddingBottom: '120px',
+    minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f5f5f5'
   },
   projectsHeader: {

--- a/frontend/src/pages/RDResults.tsx
+++ b/frontend/src/pages/RDResults.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Navbar, BottomProgressBar } from '../components/layout';
+import { formatPValue } from '../utils/format';
 import { useProgressStep } from '../hooks/useProgressStep';
 import { RDSensitivityPlot, RDScatterPlot } from '../components/charts';
 import { aiService, ResultsInterpretation } from '../services/aiService';
@@ -34,6 +35,8 @@ const RDResults: React.FC = () => {
   const [showAssumptions, setShowAssumptions] = useState(false);
   const [activeAssumption, setActiveAssumption] = useState<'continuity' | 'manipulation' | 'late'>('continuity');
   const [showDesignType, setShowDesignType] = useState(false);
+  const [outcomeLabel, setOutcomeLabel] = useState<string>('');
+  const [editingOutcomeLabel, setEditingOutcomeLabel] = useState(false);
   const [recommendedQuestions] = useState<string[]>([
     'What is the local continuity assumption in RD?',
     'How do I interpret my RD estimate?',
@@ -322,6 +325,7 @@ print(sensitivity)
 
       if (loadedResults) {
         setResults(loadedResults);
+        setOutcomeLabel(loadedResults.parameters?.outcome_var || 'outcome');
 
         // Load cached AI interpretation if it matches this analysis
         const interpretationKey = projectId
@@ -645,8 +649,41 @@ print(sensitivity)
           {/* Main Result Card */}
           <div style={styles.mainResultCard}>
             <h2 style={styles.resultLabel}>Treatment Effect</h2>
-            <div style={styles.effectValue}>
-              {res.treatment_effect.toFixed(3)}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '14px' }}>
+              <div style={styles.effectValue}>
+                {res.treatment_effect.toFixed(3)}
+              </div>
+              {editingOutcomeLabel ? (
+                <input
+                  autoFocus
+                  value={outcomeLabel}
+                  onChange={e => setOutcomeLabel(e.target.value)}
+                  onBlur={() => setEditingOutcomeLabel(false)}
+                  onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setEditingOutcomeLabel(false); }}
+                  style={{
+                    fontSize: '18px', color: '#043873',
+                    border: 'none', borderBottom: '2px solid #043873',
+                    background: 'transparent', outline: 'none',
+                    fontWeight: '500', textAlign: 'center',
+                    padding: '2px 6px', minWidth: '80px', maxWidth: '200px',
+                  }}
+                />
+              ) : (
+                <span
+                  onClick={() => setEditingOutcomeLabel(true)}
+                  title="Click to edit variable name"
+                  style={{
+                    fontSize: '17px', color: '#043873', fontWeight: '500',
+                    cursor: 'pointer', padding: '4px 10px',
+                    border: '1px dashed #b3d0ff', borderRadius: '8px',
+                    backgroundColor: '#f0f7ff',
+                    display: 'inline-flex', alignItems: 'center', gap: '5px',
+                  }}
+                >
+                  {outcomeLabel}
+                  <span style={{ fontSize: '12px', color: '#6c9bd4', marginLeft: '2px' }}>✏️</span>
+                </span>
+              )}
             </div>
             <div
               style={{
@@ -675,7 +712,7 @@ print(sensitivity)
               </div>
               <div style={styles.statRowItem}>
                 <span style={styles.statRowLabel}>P-Value</span>
-                <span style={styles.statRowValue}>{res.p_value.toFixed(4)}</span>
+                <span style={styles.statRowValue}>{formatPValue(res.p_value)}</span>
                 <button
                   type="button"
                   onClick={() => setExpandedStat((s) => (s === 'pvalue' ? null : 'pvalue'))}
@@ -705,7 +742,7 @@ print(sensitivity)
                 )}
                 {expandedStat === 'pvalue' && (
                   <p style={styles.singleExplanationText}>
-                    The p-value tests the null hypothesis that the true treatment effect is zero. It is derived from the t-statistic: t = (treatment effect − 0) / SE. In this study: t = {res.treatment_effect.toFixed(3)} / {res.se.toFixed(3)} ≈ {(res.treatment_effect / res.se).toFixed(2)}. The p-value of {res.p_value.toFixed(4)} is the probability of observing |t| at least this large when the true effect is zero (from the local polynomial regression). A p-value below 0.05 is typically considered statistically significant.
+                    The p-value tests the null hypothesis that the true treatment effect is zero. It is derived from the t-statistic: t = (treatment effect − 0) / SE. In this study: t = {res.treatment_effect.toFixed(3)} / {res.se.toFixed(3)} ≈ {(res.treatment_effect / res.se).toFixed(2)}. The p-value of {formatPValue(res.p_value)} is the probability of observing |t| at least this large when the true effect is zero (from the local polynomial regression). A p-value below 0.05 is typically considered statistically significant.
                   </p>
                 )}
                 {expandedStat === 'se' && (
@@ -1034,7 +1071,8 @@ print(sensitivity)
             runningVar={parameters.running_var}
             outcomeVar={parameters.outcome_var}
             cutoff={parameters.cutoff}
-            optimalBandwidth={bandwidth_info.optimal_bandwidth}
+            optimalBandwidth={bandwidth_info?.optimal_bandwidth}
+            selectedBandwidth={res.bandwidth_used}
             treatmentSide={parameters.treatment_side}
           />
 
@@ -1521,7 +1559,7 @@ const styles = {
   },
   container: {
     paddingTop: '70px',
-    paddingBottom: '100px',
+    paddingBottom: '120px',
     minHeight: '100vh',
     backgroundColor: '#f5f5f5',
   },

--- a/frontend/src/pages/RDSetup.tsx
+++ b/frontend/src/pages/RDSetup.tsx
@@ -896,7 +896,7 @@ export default RDSetup;
 const styles = {
   contentContainer: {
     paddingTop: '70px',
-    paddingBottom: '80px',
+    paddingBottom: '120px',
     minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f5f5f5',
   },

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Navbar, BottomProgressBar } from '../components/layout';
+import { formatPValue } from '../utils/format';
 import { useProgressStep } from '../hooks/useProgressStep';
 import { aiService, ResultsInterpretation } from '../services/aiService';
 import { useAuth } from '../contexts/AuthContext';
@@ -184,6 +185,8 @@ const ResultsPage: React.FC = () => {
     "What are the limitations of this analysis?"
   ]);
   const [datasetInfo, setDatasetInfo] = useState<any>(null);
+  const [outcomeLabel, setOutcomeLabel] = useState<string>('');
+  const [editingOutcomeLabel, setEditingOutcomeLabel] = useState(false);
   const MAX_MESSAGE_LENGTH = 2000;
   const chatMessagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -213,6 +216,7 @@ const ResultsPage: React.FC = () => {
           const parsedResults = JSON.parse(storedResults);
           loadedResults = parsedResults;
           setResults(parsedResults);
+          setOutcomeLabel(parsedResults.parameters?.outcome || 'outcome');
           // Set datasetId from results if not already set
           if (parsedResults.dataset_id) {
             loadedDatasetId = parsedResults.dataset_id;
@@ -237,6 +241,7 @@ const ResultsPage: React.FC = () => {
           if (project.lastResults) {
             loadedResults = project.lastResults;
             setResults(project.lastResults);
+            setOutcomeLabel(project.lastResults.parameters?.outcome || 'outcome');
             // Set datasetId from results
             if (project.lastResults.dataset_id) {
               loadedDatasetId = project.lastResults.dataset_id;
@@ -811,6 +816,48 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
 
               </div>
               <div style={styles.summaryCard}>
+                {/* Effect hero row */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '14px', marginBottom: '16px' }}>
+                  <div style={{
+                    fontSize: '42px', fontWeight: 'bold', color: '#043873',
+                    lineHeight: 1, fontVariantNumeric: 'tabular-nums',
+                  }}>
+                    {results?.results?.did_estimate !== null && results?.results?.did_estimate !== undefined
+                      ? `${(results.results.did_estimate > 0 ? '+' : '')}${formatNumber(results.results.did_estimate, 3)}`
+                      : '—'}
+                  </div>
+                  {editingOutcomeLabel ? (
+                    <input
+                      autoFocus
+                      value={outcomeLabel}
+                      onChange={e => setOutcomeLabel(e.target.value)}
+                      onBlur={() => setEditingOutcomeLabel(false)}
+                      onKeyDown={e => { if (e.key === 'Enter' || e.key === 'Escape') setEditingOutcomeLabel(false); }}
+                      style={{
+                        fontSize: '18px', color: '#043873',
+                        border: 'none', borderBottom: '2px solid #043873',
+                        background: 'transparent', outline: 'none',
+                        fontWeight: '500', textAlign: 'center',
+                        padding: '2px 6px', minWidth: '80px', maxWidth: '200px',
+                      }}
+                    />
+                  ) : (
+                    <span
+                      onClick={() => setEditingOutcomeLabel(true)}
+                      title="Click to edit variable name"
+                      style={{
+                        fontSize: '17px', color: '#043873', fontWeight: '500',
+                        cursor: 'pointer', padding: '4px 10px',
+                        border: '1px dashed #b3d0ff', borderRadius: '8px',
+                        backgroundColor: '#f0f7ff',
+                        display: 'inline-flex', alignItems: 'center', gap: '5px',
+                      }}
+                    >
+                      {outcomeLabel}
+                      <span style={{ fontSize: '12px', color: '#6c9bd4', marginLeft: '2px' }}>✏️</span>
+                    </span>
+                  )}
+                </div>
                 <div style={styles.summaryText}>
                   {generateAISummary()}
                 </div>
@@ -845,7 +892,7 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                     </div>
                     <div style={styles.detailItem}>
                       <span style={styles.detailLabel}>p-value:</span>
-                      <span style={styles.detailValue}>{formatNumber(results.results?.p_value, 4)}</span>
+                      <span style={styles.detailValue}>{formatPValue(results.results?.p_value)}</span>
                     </div>
                     <div style={styles.detailItem}>
                       <span style={styles.detailLabel}>Control Variables:</span>
@@ -1426,8 +1473,8 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                           }}>
                             <p style={{ margin: 0, fontSize: '15px', fontWeight: '500', color: statTestPassed ? '#155724' : '#721c24' }}>
                               {statTestPassed
-                                ? `✓ The parallel trends test passed with a high p-value (${formatNumber(statTestPValue, 2)}). This suggests the groups were changing at similar rates before treatment.`
-                                : `✗ The parallel trends test found evidence that groups were diverging before treatment (p = ${formatNumber(statTestPValue, 3)}). Interpret results with caution.`
+                                ? `✓ The parallel trends test passed with a high p-value (${formatPValue(statTestPValue)}). This suggests the groups were changing at similar rates before treatment.`
+                                : `✗ The parallel trends test found evidence that groups were diverging before treatment (p = ${formatPValue(statTestPValue)}). Interpret results with caution.`
                               }
                             </p>
                           </div>
@@ -1498,7 +1545,7 @@ ggsave("did_chart.png", width = 10, height = 6, dpi = 300)`;
                                 the treatment and control groups had different trends before treatment started.
                               </p>
                               <p style={{ marginBottom: '0', fontSize: '14px', lineHeight: '1.6', color: '#212529' }}>
-                                <strong>Your result:</strong> p-value = {formatNumber(statTestPValue, 3)}.
+                                <strong>Your result:</strong> p-value = {formatPValue(statTestPValue)}.
                                 {statTestPassed
                                   ? ' Since this is above 0.05, we fail to reject the null hypothesis that trends were parallel. This supports the parallel trends assumption.'
                                   : ' Since this is below 0.05, we reject the null hypothesis. This suggests the groups were diverging before treatment.'
@@ -2402,7 +2449,7 @@ export default ResultsPage;
 const styles = {
   contentContainer: {
     paddingTop: '70px',
-    paddingBottom: '120px', // Extra padding for bottom progress bar
+    paddingBottom: '120px',
     minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f5f5f5'
   },

--- a/frontend/src/pages/VariableSelectionPage.tsx
+++ b/frontend/src/pages/VariableSelectionPage.tsx
@@ -1517,7 +1517,7 @@ export default VariableSelectionPage;
 const styles = {
   contentContainer: {
     paddingTop: '70px',
-    paddingBottom: '80px',
+    paddingBottom: '120px',
     minHeight: 'calc(100vh - 70px)',
     backgroundColor: '#f5f5f5'
   },

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Format a p-value for display.
+ *
+ * - Values < 0.0001 are shown in scientific notation (e.g. 2.3e-6)
+ * - Values >= 0.0001 are shown with 4 decimal places (e.g. 0.0234)
+ * - Handles null / undefined / NaN gracefully
+ */
+export function formatPValue(value: number | null | undefined): string {
+  if (value === null || value === undefined || isNaN(value)) return '—';
+  if (value < 0.0001) {
+    // ToPrecision gives e.g. "2.30e-6"; clean up trailing zeros in mantissa
+    const s = value.toExponential(2);
+    return s.replace(/\.?0+(e)/, '$1');
+  }
+  return value.toFixed(4);
+}
+
+/**
+ * Format a general number to a fixed number of decimal places.
+ * Returns '—' for null/undefined/NaN.
+ */
+export function formatNumber(
+  value: number | null | undefined,
+  decimals = 3
+): string {
+  if (value === null || value === undefined || isNaN(value)) return '—';
+  return value.toFixed(decimals);
+}


### PR DESCRIPTION
Improves the causal analysis UX and AI guidance across the workflow. The backend AI assess_data_quality prompt is rewritten with stricter, explicit readiness scoring rules (ready/needs_work/not_suitable) and clarified wording for the IV screening question.

On the frontend, RD visuals now annotate the bandwidth window (new ±BW reference lines in RDScatterPlot, and a selected-bandwidth marker in RDSensitivityPlot), and results pages (DiD/RD/IV) add an inline-editable outcome label next to the headline effect.

Also adds a shared formatPValue utility (scientific notation for very small p-values) and updates pages to use it, refactors the bottom progress bar layout/buttons, tweaks Method Selection’s AI panel into separate Recommend/Chat panes with updated styling, and adjusts several pages’ bottom padding to accommodate the redesigned progress bar.

When the user clicks Next after choosing a method, the handleNext function now bundles treatmentVariable, outcomeVariable, and causalQuestion from the Recommend tab into an aiHints object in React Router's navigation state. All three destination pages (DiD, RD, IV) receive this object. 

The backend prompt now has explicit rules: only suggest a specific cutoff number when (a) the running variable is one with a well-known policy threshold (age, GPA, test score, income limit) and (b) the exact value is unambiguous (e.g. 18, 65, 70). All other cases must return "user to specify" with confidence: 0.